### PR TITLE
fix: 🐛 update umami events

### DIFF
--- a/src/components/aireadi/about.tsx
+++ b/src/components/aireadi/about.tsx
@@ -19,7 +19,8 @@ export default function About() {
             href="https://doi.org/10.1038/sdata.2016.18"
             target="_blank"
             rel="noreferrer"
-            data-umami-event="learn more bridge2ai link"
+            data-umami-event="About section link"
+            data-umami-event-text="Learn more about the NIH's Bridge2AI Program"
           >
             <p className="text-url hover-underline-animation">
               Learn more about the NIH&apos;s Bridge2AI Program
@@ -63,7 +64,8 @@ export default function About() {
                     href="https://aireadi.org"
                     target="_blank"
                     rel="noreferrer"
-                    data-umami-event="Learn more aireadi link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about the AI-READI project"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about the AI-READI project
@@ -129,7 +131,8 @@ export default function About() {
                     href="https://doi.org/10.1038/sdata.2016.18"
                     target="_blank"
                     rel="noreferrer"
-                    data-umami-event="Learn more FAIR link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about FAIR"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about FAIR

--- a/src/components/aireadi/about.tsx
+++ b/src/components/aireadi/about.tsx
@@ -19,7 +19,7 @@ export default function About() {
             href="https://doi.org/10.1038/sdata.2016.18"
             target="_blank"
             rel="noreferrer"
-            className="umami--click--learn-more-bridge2ai-link"
+            data-umami-event="learn more bridge2ai link"
           >
             <p className="text-url hover-underline-animation">
               Learn more about the NIH&apos;s Bridge2AI Program
@@ -63,7 +63,7 @@ export default function About() {
                     href="https://aireadi.org"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--learn-more-aireadi-link"
+                    data-umami-event="Learn more aireadi link"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about the AI-READI project
@@ -129,7 +129,7 @@ export default function About() {
                     href="https://doi.org/10.1038/sdata.2016.18"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--learn-more-fair-link"
+                    data-umami-event="Learn more FAIR link"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about FAIR

--- a/src/components/aireadi/hero.tsx
+++ b/src/components/aireadi/hero.tsx
@@ -40,7 +40,8 @@ export default function Hero() {
                 target="_blank"
                 aria-label="AI-READI website"
                 rel="noreferrer"
-                className="umami--click--aireadi-learnmore-button flex flex-row justify-center"
+                className="flex flex-row justify-center"
+                data-umami-event="AI-READI Learn More button"
               >
                 <button className="rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 ">
                   Learn more

--- a/src/components/aireadi/hero.tsx
+++ b/src/components/aireadi/hero.tsx
@@ -41,7 +41,8 @@ export default function Hero() {
                 aria-label="AI-READI website"
                 rel="noreferrer"
                 className="flex flex-row justify-center"
-                data-umami-event="AI-READI Learn More button"
+                data-umami-event="Hero button"
+                data-umami-event-text="AI-READI website"
               >
                 <button className="rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 ">
                   Learn more

--- a/src/components/aireadi/info.tsx
+++ b/src/components/aireadi/info.tsx
@@ -47,7 +47,8 @@ export default function Info() {
                     <a
                       href="https://github.com/AI-READI"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--fairshare-github"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="FAIRshare GitHub link"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -73,7 +74,7 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    className="umami--click--fairshare-github"
+                    data-umami-event="FAIRshare GitHub link"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -108,7 +109,8 @@ export default function Info() {
                     <a
                       href="https://reporter.nih.gov/project-details/10471118"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--aireadi-funding"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="AI-READI funding link"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -222,6 +224,7 @@ export default function Info() {
                         target="_blank"
                         rel="noreferrer"
                         className={`umami--click--${collaborator.id}-link`}
+                        data-umami-event="AI-READI collaborator link"
                       >
                         <div className="flex h-full flex-col items-center justify-end rounded-lg p-2 transition-all hover:bg-gray-200">
                           {collaborator.type === `person` ? (

--- a/src/components/aireadi/info.tsx
+++ b/src/components/aireadi/info.tsx
@@ -48,7 +48,8 @@ export default function Info() {
                       href="https://github.com/AI-READI"
                       target="_blank"
                       className="text-url hover-underline-animation"
-                      data-umami-event="FAIRshare GitHub link"
+                      data-umami-event="GitHub link"
+                      data-umami-event-project="AI-READI"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -74,7 +75,8 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    data-umami-event="FAIRshare GitHub link"
+                    data-umami-event="GitHub link"
+                    data-umami-event-project="AI-READI"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -110,7 +112,8 @@ export default function Info() {
                       href="https://reporter.nih.gov/project-details/10471118"
                       target="_blank"
                       className="text-url hover-underline-animation"
-                      data-umami-event="AI-READI funding link"
+                      data-umami-event="Funding link"
+                      data-umami-event-project="AI-READI"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -206,9 +209,9 @@ export default function Info() {
                     institutions collaborating on the AI-READI project include:
                     University of Washington, Oregon Health & Science
                     University, Johns Hopkins University, University of
-                    California at San Diego, University of Pennsylvania,
-                    Stanford University, Native BioData Consortium, University
-                    of Alabama at Birmingham, and Microsoft.
+                    California at San Diego, Stanford University, Native BioData
+                    Consortium, University of Alabama at Birmingham, and
+                    Microsoft.
                   </p>
                 </div>
               </div>

--- a/src/components/aireadi/publications.tsx
+++ b/src/components/aireadi/publications.tsx
@@ -13,8 +13,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.1101/2022.04.18.488694"
             target="_blank"
-            className="umami--click--10-1101-2022-04-18-488694-link my-2"
-            data-umami-event="10-1101-2022-04-18-488694-link"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.1101/2022.04.18.488694"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -33,8 +34,8 @@ export default function Publications() {
                 href="https://doi.org/10.1101/2022.04.18.488694"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-1101-2022-04-18-488694-link"
-                data-umami-event="10-1101-2022-04-18-488694-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.1101/2022.04.18.488694"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   https://doi.org/10.1101/2022.04.18.488694

--- a/src/components/aireadi/publications.tsx
+++ b/src/components/aireadi/publications.tsx
@@ -14,6 +14,7 @@ export default function Publications() {
             href="https://doi.org/10.1101/2022.04.18.488694"
             target="_blank"
             className="umami--click--10-1101-2022-04-18-488694-link my-2"
+            data-umami-event="10-1101-2022-04-18-488694-link"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -33,6 +34,7 @@ export default function Publications() {
                 target="_blank"
                 rel="noreferrer"
                 className="umami--click--10-1101-2022-04-18-488694-link"
+                data-umami-event="10-1101-2022-04-18-488694-link"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   https://doi.org/10.1101/2022.04.18.488694

--- a/src/components/aqua/about.tsx
+++ b/src/components/aqua/about.tsx
@@ -39,7 +39,7 @@ export default function About() {
                     href="https://sparc.science/"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--NIH-sparc-link"
+                    data-umami-event="NIH-sparc-link"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SPARC
@@ -85,7 +85,7 @@ export default function About() {
                     href="https://doi.org/10.1101/2021.02.10.430563"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--SDS-link"
+                    data-umami-event="SDS-link"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SDS

--- a/src/components/aqua/about.tsx
+++ b/src/components/aqua/about.tsx
@@ -39,7 +39,8 @@ export default function About() {
                     href="https://sparc.science/"
                     target="_blank"
                     rel="noreferrer"
-                    data-umami-event="NIH-sparc-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SPARC"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SPARC
@@ -85,7 +86,8 @@ export default function About() {
                     href="https://doi.org/10.1101/2021.02.10.430563"
                     target="_blank"
                     rel="noreferrer"
-                    data-umami-event="SDS-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SDS"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SDS

--- a/src/components/aqua/hero.tsx
+++ b/src/components/aqua/hero.tsx
@@ -37,7 +37,10 @@ export default function Hero() {
                 target="_blank"
                 rel="noreferrer"
               >
-                <button className="umami--click--aqua-demo-button flex items-center justify-center rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600">
+                <button
+                  className="flex items-center justify-center rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+                  data-umami-event="AQUA Demo button"
+                >
                   Explore AQUA
                 </button>
               </a>
@@ -46,7 +49,10 @@ export default function Hero() {
                 target="_blank"
                 rel="noreferrer"
               >
-                <button className="umami--click--aqua-docs-button ml-4 rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600">
+                <button
+                  className="ml-4 rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+                  data-umami-event="AQUA Docs button"
+                >
                   Documentation
                 </button>
               </a>

--- a/src/components/aqua/hero.tsx
+++ b/src/components/aqua/hero.tsx
@@ -39,7 +39,8 @@ export default function Hero() {
               >
                 <button
                   className="flex items-center justify-center rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
-                  data-umami-event="AQUA Demo button"
+                  data-umami-event="Hero button"
+                  data-umami-event-text="Explore AQUA"
                 >
                   Explore AQUA
                 </button>
@@ -51,7 +52,8 @@ export default function Hero() {
               >
                 <button
                   className="ml-4 rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
-                  data-umami-event="AQUA Docs button"
+                  data-umami-event="Hero button"
+                  data-umami-event-text="AQUA Documentation"
                 >
                   Documentation
                 </button>

--- a/src/components/aqua/info.tsx
+++ b/src/components/aqua/info.tsx
@@ -59,7 +59,9 @@ export default function Info() {
                       href="https://github.com/fairdataihub/AQUA/graphs/contributors"
                       target="_blank"
                       className="mr-2"
-                      data-umami-event="Aqua Contributors Badge"
+                      data-umami-event="Badge"
+                      data-umami-event-project="AQUA"
+                      data-umami-event-type="Contributors"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -72,7 +74,9 @@ export default function Info() {
                       href="https://github.com/fairdataihub/AQUA/stargazers"
                       target="_blank"
                       className="mr-2"
-                      data-umami-event="Aqua Stars Badge"
+                      data-umami-event="Badge"
+                      data-umami-event-project="AQUA"
+                      data-umami-event-type="Stars"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -85,7 +89,9 @@ export default function Info() {
                       href="https://github.com/fairdataihub/AQUA/issues"
                       target="_blank"
                       className="mr-2"
-                      data-umami-event="Aqua Issues Badge"
+                      data-umami-event="Badge"
+                      data-umami-event-project="AQUA"
+                      data-umami-event-type="Issues"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -98,7 +104,9 @@ export default function Info() {
                       href="https://github.com/fairdataihub/AQUA/blob/master/LICENSE"
                       target="_blank"
                       className="mr-2"
-                      data-umami-event="Aqua License Badge"
+                      data-umami-event="Badge"
+                      data-umami-event-project="AQUA"
+                      data-umami-event-type="License"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -113,7 +121,8 @@ export default function Info() {
                       href="https://github.com/SPARC-FAIR-Codeathon/AQUA"
                       target="_blank"
                       className="text-url hover-underline-animation"
-                      data-umami-event="Aqua GitHub Link"
+                      data-umami-event="GitHub link"
+                      data-umami-event-project="AQUA"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -139,7 +148,8 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    data-umami-event="Aqua GitHub Link"
+                    data-umami-event="GitHub link"
+                    data-umami-event-project="AQUA"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -178,7 +188,8 @@ export default function Info() {
                       href="https://sparc.science/help/2021-sparc-fair-codeathon"
                       target="_blank"
                       className="text-url hover-underline-animation"
-                      data-umami-event="SPARC FAIR 2021 Codeathon link"
+                      data-umami-event="Info section link"
+                      data-umami-event-text="Learn more about the SPARC Codeathon"
                       rel="noreferrer"
                     >
                       <span className="font-lato">

--- a/src/components/aqua/info.tsx
+++ b/src/components/aqua/info.tsx
@@ -58,7 +58,8 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/AQUA/graphs/contributors"
                       target="_blank"
-                      className="umami--click--aqua-contributors-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Aqua Contributors Badge"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -70,7 +71,8 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/AQUA/stargazers"
                       target="_blank"
-                      className="umami--click--aqua-stars-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Aqua Stars Badge"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -82,7 +84,8 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/AQUA/issues"
                       target="_blank"
-                      className="umami--click--aqua-issues-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Aqua Issues Badge"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -94,7 +97,8 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/AQUA/blob/master/LICENSE"
                       target="_blank"
-                      className="umami--click--aqua-license-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Aqua License Badge"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -108,7 +112,8 @@ export default function Info() {
                     <a
                       href="https://github.com/SPARC-FAIR-Codeathon/AQUA"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--aqua-github"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="Aqua GitHub Link"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -134,7 +139,7 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    className="umami--click--aqua-github"
+                    data-umami-event="Aqua GitHub Link"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -172,7 +177,8 @@ export default function Info() {
                     <a
                       href="https://sparc.science/help/2021-sparc-fair-codeathon"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--sparc-fair-21-codeathon"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="SPARC FAIR 2021 Codeathon link"
                       rel="noreferrer"
                     >
                       <span className="font-lato">

--- a/src/components/aqua/publications.tsx
+++ b/src/components/aqua/publications.tsx
@@ -13,7 +13,8 @@ export default function Publications() {
             href="https://doi.org/10.12688/f1000research.73018.1"
             target="_blank"
             className="my-2"
-            data-umami-event="10.12688/f1000research.73018.1 Link"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.12688/f1000research.73018.1"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -31,7 +32,8 @@ export default function Publications() {
                 href="https://doi.org/10.12688/f1000research.73018.1"
                 target="_blank"
                 rel="noreferrer"
-                data-umami-event="10.12688/f1000research.73018.1 Link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.12688/f1000research.73018.1"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   doi.org/10.12688/f1000research.73018.1

--- a/src/components/aqua/publications.tsx
+++ b/src/components/aqua/publications.tsx
@@ -12,7 +12,8 @@ export default function Publications() {
           <a
             href="https://doi.org/10.12688/f1000research.73018.1"
             target="_blank"
-            className="umami--click--10-12688-f1000research-73018-1-link my-2"
+            className="my-2"
+            data-umami-event="10.12688/f1000research.73018.1 Link"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -30,7 +31,7 @@ export default function Publications() {
                 href="https://doi.org/10.12688/f1000research.73018.1"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-12688-f1000research-73018-1-link"
+                data-umami-event="10.12688/f1000research.73018.1 Link"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   doi.org/10.12688/f1000research.73018.1

--- a/src/components/blog/postEntry.tsx
+++ b/src/components/blog/postEntry.tsx
@@ -42,7 +42,12 @@ const postEntry: React.FC<PostEntryProps> = ({
       <div className="flex flex-col rounded-lg px-2 py-7 transition-all hover:bg-stone-100 hover:shadow-sm md:w-8/12 md:py-5 md:px-7">
         {category !== `` && (
           <Link href={`/category/${category}`} passHref>
-            <h3 className="text-url umami--click--blog-article-category mb-1 cursor-pointer text-base font-semibold hover:underline md:hidden">
+            <h3
+              className="text-url mb-1 cursor-pointer text-base font-semibold hover:underline md:hidden"
+              data-umami-event="Blog"
+              data-umami-event-action="Category"
+              data-umami-event-value={category}
+            >
               {category}
             </h3>
           </Link>
@@ -71,7 +76,12 @@ const postEntry: React.FC<PostEntryProps> = ({
             <h3 className="mr-2 text-sm font-bold">Tags: </h3>
             {tags.map((tag) => (
               <Link href={`/tags/${tag}`} key={tag}>
-                <span className="umami--click--blog-article-tag mr-2 cursor-pointer rounded-lg border border-slate-300 px-1 transition-all hover:border-light-accent hover:text-accent">
+                <span
+                  className="mr-2 cursor-pointer rounded-lg border border-slate-300 px-1 transition-all hover:border-light-accent hover:text-accent"
+                  data-umami-event="Blog"
+                  data-umami-event-action="Tag"
+                  data-umami-event-value={tag}
+                >
                   {tag}
                 </span>
               </Link>

--- a/src/components/contact-us/contactForm.jsx
+++ b/src/components/contact-us/contactForm.jsx
@@ -159,7 +159,8 @@ const ContactForm = () => (
             <button
               type="submit"
               disabled={isSubmitting}
-              className="umami--click--contact-us-submit-button cursor-pointer rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+              className="cursor-pointer rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+              data-umami-event="Contact Us Submit button"
             >
               Submit
             </button>

--- a/src/components/contact-us/contactForm.jsx
+++ b/src/components/contact-us/contactForm.jsx
@@ -67,15 +67,19 @@ const ContactForm = () => (
         fetch(`/api/contact`, {
           method: `POST`,
           body: JSON.stringify(values),
-        }).then(async (response) => {
-          const res = await response.json();
-          if (res.success) {
-            successNotify();
-            handleReset();
-          } else {
+        })
+          .then(async (response) => {
+            const res = await response.json();
+            if (res.success) {
+              successNotify();
+              handleReset();
+            } else {
+              errorNotify();
+            }
+          })
+          .catch((_error) => {
             errorNotify();
-          }
-        });
+          });
 
         setSubmitting(false);
       }}

--- a/src/components/fairshare/about.tsx
+++ b/src/components/fairshare/about.tsx
@@ -43,7 +43,8 @@ export default function About() {
                     href="https://doi.org/10.1038/sdata.2016.18"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--learn-more-fair-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about FAIR"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about FAIR

--- a/src/components/fairshare/hero.tsx
+++ b/src/components/fairshare/hero.tsx
@@ -52,7 +52,9 @@ export default function Hero() {
                 <div className="flex flex-row justify-center">
                   <a
                     href={downloadURL}
-                    className="umami--click--fairshare-download-button rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 sm:block"
+                    className="rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 sm:block"
+                    data-umami-event="Hero button"
+                    data-umami-event-text="Download FAIRshare"
                   >
                     Download now
                   </a>
@@ -63,7 +65,9 @@ export default function Hero() {
                 target="_blank"
                 aria-label="FAIRshare Documentation"
                 rel="noreferrer"
-                className="umami--click--fairshare-docs-button flex flex-row justify-center"
+                className="flex flex-row justify-center"
+                data-umami-event="Hero button"
+                data-umami-event-text="FAIRshare Documentation"
               >
                 <button className="rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 ">
                   Explore the docs

--- a/src/components/fairshare/hero.tsx
+++ b/src/components/fairshare/hero.tsx
@@ -11,7 +11,10 @@ export default function Hero() {
       const url = await getLatestDownloadLink(`fairdataihub/FAIRshare`);
       setDownloadURL(url);
     };
-    func();
+
+    func().catch((e) => {
+      console.error(e);
+    });
   }, []);
 
   return (

--- a/src/components/fairshare/info.tsx
+++ b/src/components/fairshare/info.tsx
@@ -77,7 +77,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/FAIRshare/graphs/contributors"
                       target="_blank"
-                      className="umami--click--fairshare-contributors-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="FAIRshare"
+                      data-umami-event-type="Contributors"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -89,7 +92,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/FAIRshare/stargazers"
                       target="_blank"
-                      className="umami--click--fairshare-stars-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="FAIRshare"
+                      data-umami-event-type="Stars"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -101,7 +107,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/FAIRshare/issues"
                       target="_blank"
-                      className="umami--click--fairshare-issues-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="FAIRshare"
+                      data-umami-event-type="Issues"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -113,7 +122,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/FAIRshare/blob/master/LICENSE"
                       target="_blank"
-                      className="umami--click--fairshare-license-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="FAIRshare"
+                      data-umami-event-type="License"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -127,7 +139,9 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/FAIRshare"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--fairshare-github"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="GitHub link"
+                      data-umami-event-project="FAIRshare"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -153,7 +167,8 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    className="umami--click--fairshare-github"
+                    data-umami-event="GitHub link"
+                    data-umami-event-project="FAIRshare"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -189,7 +204,9 @@ export default function Info() {
                     <a
                       href="https://reporter.nih.gov/project-details/10377989"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--fairshare-funding"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="Funding link"
+                      data-umami-event-project="FAIRshare"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -311,7 +328,8 @@ export default function Info() {
                         href={collaborator.href}
                         target="_blank"
                         rel="noreferrer"
-                        className={`umami--click--${collaborator.id}-link`}
+                        data-umami-event="Collaborator link"
+                        data-umami-event-value={collaborator.id}
                       >
                         <div className="flex h-full flex-col items-center justify-end rounded-lg p-2 transition-all hover:bg-gray-200 ">
                           {collaborator.type === `person` ? (

--- a/src/components/fairshare/publications.tsx
+++ b/src/components/fairshare/publications.tsx
@@ -12,7 +12,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.1101/2022.04.18.488694"
             target="_blank"
-            className="umami--click--10-1101-2022-04-18-488694-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.1101/2022.04.18.488694"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -31,7 +33,8 @@ export default function Publications() {
                 href="https://doi.org/10.1101/2022.04.18.488694"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-1101-2022-04-18-488694-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.1101/2022.04.18.488694"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   https://doi.org/10.1101/2022.04.18.488694
@@ -44,7 +47,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.7490/f1000research.1119054.1"
             target="_blank"
-            className="umami--click--10-7490-f1000research-1119054-1-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.7490/f1000research.1119054.1"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold ">
@@ -66,7 +71,8 @@ export default function Publications() {
                 href="https://doi.org/10.7490/f1000research.1119054.1"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-7490-f1000research-1119054-1-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.7490/f1000research.1119054.1"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   https://doi.org/10.7490/f1000research.1119054.1
@@ -79,7 +85,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.7490/f1000research.1119055.1"
             target="_blank"
-            className="umami--click--10.7490-f1000research-1119055-1-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.7490/f1000research.1119055.1"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold ">
@@ -102,7 +110,8 @@ export default function Publications() {
                 href="https://doi.org/10.7490/f1000research.1119055.1"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10.7490-f1000research-1119055-1-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.7490/f1000research.1119055.1"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   https://doi.org/10.7490/f1000research.1119055.1

--- a/src/components/home/aboutUs.tsx
+++ b/src/components/home/aboutUs.tsx
@@ -38,7 +38,9 @@ export default function AboutUs() {
             <Link href="/team" passHref>
               <button
                 type="button"
-                className="umami--click--meet-the-team-button w-max rounded-md border-none bg-black px-6 py-4 text-center text-base font-semibold text-white ring-2 ring-transparent ring-offset-2 transition duration-200 ease-in-out hover:ring-pink-600 focus:ring-pink-600"
+                className="w-max rounded-md border-none bg-black px-6 py-4 text-center text-base font-semibold text-white ring-2 ring-transparent ring-offset-2 transition duration-200 ease-in-out hover:ring-pink-600 focus:ring-pink-600"
+                data-umami-event="Home page link"
+                data-umami-event-value="Meet our team"
               >
                 Meet our team
               </button>

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -28,7 +28,9 @@ export default function Hero() {
             <Link href="/contact-us" passHref>
               <button
                 type="button"
-                className="umami--click--contact-us-button my-3 rounded-lg border-2 border-black bg-transparent p-3 text-center text-base font-semibold text-black transition-all hover:border-light-accent hover:text-accent"
+                className="my-3 rounded-lg border-2 border-black bg-transparent p-3 text-center text-base font-semibold text-black transition-all hover:border-light-accent hover:text-accent"
+                data-umami-event="Home page link"
+                data-umami-event-value="Contact us"
               >
                 Contact us
               </button>

--- a/src/components/home/projectsCarousel.tsx
+++ b/src/components/home/projectsCarousel.tsx
@@ -166,10 +166,9 @@ export default function ProjectsCarousel() {
                       <div className="flex w-full justify-center py-4">
                         <Link href={project.page} passHref>
                           <button
-                            className={
-                              `inline-flex rounded border-0 bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition hover:ring-pink-600 focus:outline-none focus:ring-pink-600 sm:ml-4 md:text-base lg:text-lg ` +
-                              `umami--click--${project.id}-button`
-                            }
+                            className="inline-flex rounded border-0 bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition hover:ring-pink-600 focus:outline-none focus:ring-pink-600 sm:ml-4 md:text-base lg:text-lg"
+                            data-umami-event="Projects Carousel link"
+                            data-umami-value={project.id}
                           >
                             Learn more about {project.name}
                           </button>

--- a/src/components/knowmore/about.tsx
+++ b/src/components/knowmore/about.tsx
@@ -42,7 +42,8 @@ export default function About() {
                     href="https://sparc.science/"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--NIH-sparc-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SPARC"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SPARC
@@ -87,7 +88,8 @@ export default function About() {
                     href="https://doi.org/10.1101/2021.02.10.430563"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--SDS-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SDS"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SDS

--- a/src/components/knowmore/hero.tsx
+++ b/src/components/knowmore/hero.tsx
@@ -40,7 +40,11 @@ export default function Hero() {
                 rel="noreferrer"
                 className="flex flex-row justify-center"
               >
-                <button className="umami--click--knowmore-demo-button rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600">
+                <button
+                  className="rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+                  data-umami-event="Hero button"
+                  data-umami-event-text="Test KnowMore"
+                >
                   Test KnowMore
                 </button>
               </a>
@@ -50,7 +54,11 @@ export default function Hero() {
                 rel="noreferrer"
                 className="flex flex-row justify-center"
               >
-                <button className="umami--click--knowmore-docs-button rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600">
+                <button
+                  className=" rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+                  data-umami-event="Hero button"
+                  data-umami-event-text="KnowMore Documentation"
+                >
                   Documentation
                 </button>
               </a>

--- a/src/components/knowmore/info.tsx
+++ b/src/components/knowmore/info.tsx
@@ -54,7 +54,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/KnowMore/graphs/contributors"
                       target="_blank"
-                      className="umami--click--knowmore-contributors-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="KnowMore"
+                      data-umami-event-type="Contributors"
                       rel="noreferrer relative"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -66,7 +69,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/KnowMore/stargazers"
                       target="_blank"
-                      className="umami--click--knowmore-stars-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="KnowMore"
+                      data-umami-event-type="Stars"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -78,7 +84,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/KnowMore/issues"
                       target="_blank"
-                      className="umami--click--knowmore-issues-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="KnowMore"
+                      data-umami-event-type="Issues"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -90,7 +99,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/KnowMore/blob/master/LICENSE"
                       target="_blank"
-                      className="umami--click--knowmore-license-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="KnowMore"
+                      data-umami-event-type="License"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -104,7 +116,9 @@ export default function Info() {
                     <a
                       href="https://github.com/SPARC-FAIR-Codeathon/KnowMore"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--knowmore-github"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="GitHub link"
+                      data-umami-event-project="KnowMore"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -130,7 +144,8 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    className="umami--click--knowmore-github"
+                    data-umami-event="GitHub link"
+                    data-umami-event-project="KnowMore"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -168,7 +183,9 @@ export default function Info() {
                     <a
                       href="https://sparc.science/help/2021-sparc-fair-codeathon"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--sparc-fair-21-codeathon"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="Info section link"
+                      data-umami-event-text="Learn more about the SPARC Codeathon"
                       rel="noreferrer"
                     >
                       <span className="font-lato">

--- a/src/components/knowmore/publications.tsx
+++ b/src/components/knowmore/publications.tsx
@@ -12,7 +12,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.1101/2021.08.08.455581"
             target="_blank"
-            className="umami--click--10-1101-2021-08-08-455581-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.1101/2021.08.08.455581"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -31,7 +33,8 @@ export default function Publications() {
                 href="https://doi.org/10.1101/2021.08.08.455581"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-1101-2021-08-08-455581-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.1101/2021.08.08.455581"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   doi.org/10.1101/2021.08.08.455581

--- a/src/components/sodaforsparc/about.tsx
+++ b/src/components/sodaforsparc/about.tsx
@@ -41,7 +41,8 @@ export default function About() {
                     href="https://sparc.science/"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--NIH-sparc-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SPARC"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SPARC
@@ -86,7 +87,8 @@ export default function About() {
                     href="https://doi.org/10.1038/sdata.2016.18"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--SDS-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SPARC"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SDS

--- a/src/components/sodaforsparc/hero.tsx
+++ b/src/components/sodaforsparc/hero.tsx
@@ -11,7 +11,10 @@ export default function Hero() {
       const url = await getLatestDownloadLink(`fairdataihub/SODA-for-SPARC`);
       setDownloadURL(url);
     };
-    func();
+
+    func().catch((e) => {
+      console.error(e);
+    });
   }, []);
 
   return (

--- a/src/components/sodaforsparc/hero.tsx
+++ b/src/components/sodaforsparc/hero.tsx
@@ -51,7 +51,9 @@ export default function Hero() {
                 <div className="flex flex-row justify-center">
                   <a
                     href={downloadURL}
-                    className="umami--click--soda-sparc-download-button rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 sm:block"
+                    className="rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600 sm:block"
+                    data-umami-event="Hero button"
+                    data-umami-event-text="SODA for SPARC Download"
                   >
                     Download now
                   </a>
@@ -61,7 +63,9 @@ export default function Hero() {
                 href="https://docs.sodaforsparc.io/"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--soda-sparc-docs-button flex flex-row justify-center"
+                className="flex flex-row justify-center"
+                data-umami-event="Hero button"
+                data-umami-event-text="SODA for SPARC Docs"
               >
                 <button className=" rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600">
                   Explore the docs

--- a/src/components/sodaforsparc/info.tsx
+++ b/src/components/sodaforsparc/info.tsx
@@ -85,7 +85,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SODA-for-SPARC/graphs/contributors"
                       target="_blank"
-                      className="umami--click--soda-sparc-contributors-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SODA for SPARC"
+                      data-umami-event-type="Contributors"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -97,7 +100,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SODA-for-SPARC/stargazers"
                       target="_blank"
-                      className="umami--click--soda-sparc-stars-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SODA for SPARC"
+                      data-umami-event-type="Stars"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -109,7 +115,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SODA-for-SPARC/issues"
                       target="_blank"
-                      className="umami--click--soda-sparc-issues-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SODA for SPARC"
+                      data-umami-event-type="Issues"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -121,7 +130,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SODA-for-SPARC/blob/master/LICENSE"
                       target="_blank"
-                      className="umami--click--soda-sparc-license-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SODA for SPARC"
+                      data-umami-event-type="License"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -135,7 +147,9 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SODA-for-SPARC"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--soda-sparc-github"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="GitHub link"
+                      data-umami-event-project="SODA for SPARC"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -161,7 +175,8 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    className="umami--click--soda-sparc-github"
+                    data-umami-event="GitHub link"
+                    data-umami-event-project="SODA for SPARC"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -200,7 +215,9 @@ export default function Info() {
                     <a
                       href="https://reporter.nih.gov/search/ZGaCL05IVE6SWFIbPlZFrg/project-details/10175565"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--soda-sparc-funding"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="Funding link"
+                      data-umami-event-project="SODA for SPARC"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -349,7 +366,8 @@ export default function Info() {
                         href={collaborator.href}
                         target="_blank"
                         rel="noreferrer"
-                        className={`umami--click--${collaborator.id}-link`}
+                        data-umami-event="Collaborator link"
+                        data-umami-event-value={collaborator.id}
                       >
                         <div className="flex h-full flex-col items-center rounded-lg p-2 transition-all hover:bg-gray-200">
                           <Image

--- a/src/components/sodaforsparc/publications.tsx
+++ b/src/components/sodaforsparc/publications.tsx
@@ -12,7 +12,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.1101/2021.02.10.430563"
             target="_blank"
-            className="umami--click--10-1101-2021-02-10-430563-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.1101/2021.02.10.430563"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -32,7 +34,8 @@ export default function Publications() {
                 href="https://doi.org/10.1101/2021.02.10.430563"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-1101-2021-02-10-430563-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.1101/2021.02.10.430563"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   doi.org/10.1101/2021.02.10.430563
@@ -45,7 +48,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.1096/fasebj.2020.34.s1.02483"
             target="_blank"
-            className="umami--click--10-1096-fasebj-2020-34-s1-02483-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.1096/fasebj.2020.34.s1.02483"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -63,7 +68,8 @@ export default function Publications() {
                 href="https://doi.org/10.1096/fasebj.2020.34.s1.02483"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-1096-fasebj-2020-34-s1-02483-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.1096/fasebj.2020.34.s1.02483"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   doi.org/10.1096/fasebj.2020.34.s1.02483

--- a/src/components/sparclink/about.tsx
+++ b/src/components/sparclink/about.tsx
@@ -41,7 +41,8 @@ export default function About() {
                     href="https://sparc.science/"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--NIH-sparc-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about SPARC"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SPARC
@@ -86,7 +87,8 @@ export default function About() {
                     href="https://doi.org/10.1101/2021.02.10.430563"
                     target="_blank"
                     rel="noreferrer"
-                    className="umami--click--SDS-link"
+                    data-umami-event="About section link"
+                    data-umami-event-text="Learn more about the SDS"
                   >
                     <p className="text-url hover-underline-animation">
                       Learn more about SDS

--- a/src/components/sparclink/hero.tsx
+++ b/src/components/sparclink/hero.tsx
@@ -38,7 +38,11 @@ export default function Hero() {
                 target="_blank"
                 rel="noreferrer"
               >
-                <button className="umami--click--sparclink-demo-button flex items-center justify-center rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600">
+                <button
+                  className="flex items-center justify-center rounded border-0 border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none focus:ring-pink-600"
+                  data-umami-event="Hero button"
+                  data-umami-event-text="Explore SPARClink"
+                >
                   Explore SPARClink
                 </button>
               </a>

--- a/src/components/sparclink/info.tsx
+++ b/src/components/sparclink/info.tsx
@@ -58,7 +58,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SPARClink/graphs/contributors"
                       target="_blank"
-                      className="umami--click--sparclink-contributors-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SPARClink"
+                      data-umami-event-type="Contributors"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -70,7 +73,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SPARClink/stargazers"
                       target="_blank"
-                      className="umami--click--sparclink-stars-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SPARClink"
+                      data-umami-event-type="Stars"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -82,7 +88,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SPARClink/issues"
                       target="_blank"
-                      className="umami--click--sparclink-issues-badge mr-2"
+                      className="mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SPARClink"
+                      data-umami-event-type="Issues"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -94,7 +103,10 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SPARClink/blob/master/LICENSE"
                       target="_blank"
-                      className="umami--click--sparclink-license-badge mr-2"
+                      className=" mr-2"
+                      data-umami-event="Badge"
+                      data-umami-event-project="SPARClink"
+                      data-umami-event-type="License"
                       rel="noreferrer"
                     >
                       {/*  eslint-disable-next-line @next/next/no-img-element */}
@@ -108,7 +120,9 @@ export default function Info() {
                     <a
                       href="https://github.com/fairdataihub/SPARClink"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--sparclink-github"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="GitHub link"
+                      data-umami-event-project="SPARClink"
                       rel="noreferrer"
                     >
                       <span className="font-lato">
@@ -134,7 +148,8 @@ export default function Info() {
                     target="_blank"
                     rel="noreferrer"
                     aria-label="Github"
-                    className="umami--click--sparclink-github"
+                    data-umami-event="GitHub link"
+                    data-umami-event-project="SPARClink"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -173,7 +188,9 @@ export default function Info() {
                     <a
                       href="https://sparc.science/help/2021-sparc-fair-codeathon"
                       target="_blank"
-                      className="text-url hover-underline-animation umami--click--sparc-fair-21-codeathon"
+                      className="text-url hover-underline-animation"
+                      data-umami-event="Info section link"
+                      data-umami-event-text="Learn more about the SPARC Codeathon"
                       rel="noreferrer"
                     >
                       <span className="font-lato">

--- a/src/components/sparclink/publications.tsx
+++ b/src/components/sparclink/publications.tsx
@@ -12,7 +12,9 @@ export default function Publications() {
           <a
             href="https://doi.org/10.12688/f1000research.75071.1"
             target="_blank"
-            className="umami--click--10-12688-f1000research-75071-1-link my-2"
+            className="my-2"
+            data-umami-event="Publication DOI link"
+            data-umami-event-doi="10.12688/f1000research.75071.1"
             rel="noreferrer"
           >
             <p className="text-url text-xl font-semibold">
@@ -31,7 +33,8 @@ export default function Publications() {
                 href="https://doi.org/10.12688/f1000research.75071.1"
                 target="_blank"
                 rel="noreferrer"
-                className="umami--click--10-12688-f1000research-75071-1-link"
+                data-umami-event="Publication DOI link"
+                data-umami-event-doi="10.12688/f1000research.75071.1"
               >
                 <span className="break-words text-blue-600 hover:underline">
                   https://doi.org/10.12688/f1000research.75071.1

--- a/src/components/team/teamCard.tsx
+++ b/src/components/team/teamCard.tsx
@@ -75,7 +75,10 @@ const TeamCard: React.FC<TeamCardProps> = ({ profile }) => {
               href={profile.twitter.link}
               target="_blank"
               rel="noreferrer"
-              className={`px-1 ` + `umami--click--${profile.id}-twitter`}
+              className="px-1"
+              data-umami-event="Team Member Social Media"
+              data-umami-event-id={`${profile.id}`}
+              data-umami-event-type="Twitter"
               aria-label="Twitter"
             >
               <svg
@@ -95,7 +98,10 @@ const TeamCard: React.FC<TeamCardProps> = ({ profile }) => {
               href={profile.github.link}
               target="_blank"
               rel="noreferrer"
-              className={`px-1 ` + `umami--click--${profile.id}-github`}
+              className="px-1"
+              data-umami-event="Team Member Social Media"
+              data-umami-event-id={`${profile.id}`}
+              data-umami-event-type="GitHub"
               aria-label="Github"
             >
               <svg
@@ -115,7 +121,10 @@ const TeamCard: React.FC<TeamCardProps> = ({ profile }) => {
               href={profile.linkedin.link}
               target="_blank"
               rel="noreferrer"
-              className={`px-1 ` + `umami--click--${profile.id}-linkedin`}
+              className="px-1"
+              data-umami-event="Team Member Social Media"
+              data-umami-event-id={`${profile.id}`}
+              data-umami-event-type="LinkedIn"
               aria-label="LinkedIn"
             >
               <svg

--- a/src/components/ui/footer.tsx
+++ b/src/components/ui/footer.tsx
@@ -35,7 +35,10 @@ export default function Footer() {
             <div className="flex flex-row justify-start py-3">
               <a
                 href="https://www.twitter.com/fairdataihub"
-                className="icon-style umami--click--twitter-profile"
+                className="icon-style"
+                data-umami-event="Navigation link"
+                data-umami-event-location="Footer"
+                data-umami-event-value="Twitter"
                 aria-label="Twitter"
                 rel="noopener"
               >
@@ -52,7 +55,10 @@ export default function Footer() {
               </a>
               <a
                 href="https://www.linkedin.com/company/california-medical-innovations-institute"
-                className="icon-style umami--click--linkedin-profile"
+                className="icon-style"
+                data-umami-event="Navigation link"
+                data-umami-event-location="Footer"
+                data-umami-event-value="LinkedIn"
                 aria-label="Linked In"
                 rel="noopener"
               >
@@ -75,7 +81,10 @@ export default function Footer() {
               <a
                 href="https://github.com/fairdataihub"
                 target="_blank"
-                className="icon-style umami--click--github-profile"
+                className="icon-style"
+                data-umami-event="Navigation link"
+                data-umami-event-location="Footer"
+                data-umami-event-value="GitHub"
                 aria-label="Github"
                 rel="noreferrer"
               >
@@ -95,49 +104,112 @@ export default function Footer() {
             className="grid w-full grid-cols-2 gap-10 md:w-7/12 md:grid-cols-3 md:gap-6"
           >
             <div className="flex flex-col">
-              <h3 className="footer-header">Company</h3>
+              <h3 className="footer-header"> Company </h3>
               <ul>
-                <li className="footer-item umami--click--about-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="About"
+                >
                   <Link href="/team"> About </Link>
                 </li>
-                <li className="footer-item umami--click--blog-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="Blog"
+                >
                   <Link href="/blog"> Blog </Link>
                 </li>
-                <li className="footer-item  umami--click--contact-us-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="Contact Us"
+                >
                   <Link href="/contact-us"> Contact Us </Link>
                 </li>
               </ul>
             </div>
             <div className="flex flex-col">
-              <h3 className="footer-header">Legal</h3>
+              <h3 className="footer-header"> Legal </h3>
               <ul>
-                <li className="footer-item umami--click--terms-of-use-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="Terms of Use"
+                >
                   <Link href="/termsofuse"> Terms of Use </Link>
                 </li>
-                <li className="footer-item umami--click--privacy-policy-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="Privacy Policy"
+                >
                   <Link href="/privacypolicy"> Privacy Policy </Link>
                 </li>
-                <li className="footer-item umami--click--cookie-policy-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="Cookie Policy"
+                >
                   <Link href="/cookiepolicy"> Cookie Policy </Link>
                 </li>
               </ul>
             </div>
             <div className="flex flex-col font-inter">
-              <h3 className="footer-header">Products</h3>
+              <h3 className="footer-header"> Products </h3>
               <ul>
-                <li className="footer-item umami--click--soda-for-sparc-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="SODA for SPARC"
+                >
                   <Link href="/sodaforsparc"> SODA for SPARC </Link>
                 </li>
-                <li className="footer-item umami--click--fairshare-footer">
-                  <Link href="/fairshare">FAIRshare</Link>
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="AI-READI"
+                >
+                  <Link href="/aireadi"> AI-READI </Link>
                 </li>
-                <li className="footer-item umami--click--knowmore-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="FAIRshare"
+                >
+                  <Link href="/fairshare"> FAIRshare </Link>
+                </li>
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="KnowMore"
+                >
                   <Link href="/knowmore"> KnowMore </Link>
                 </li>
-                <li className="footer-item umami--click--sparclink-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="SPARClink"
+                >
                   <Link href="/sparclink"> SPARClink </Link>
                 </li>
-                <li className="footer-item umami--click--aqua-footer">
+                <li
+                  className="footer-item"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Footer"
+                  data-umami-event-value="AQUA"
+                >
                   <Link href="/aqua"> AQUA </Link>
                 </li>
               </ul>
@@ -149,8 +221,8 @@ export default function Footer() {
 
         <div className="mt-3 flex h-full flex-col items-center justify-center space-y-4 space-x-0 divide-x-2 divide-none divide-gray-200 py-5 md:flex-row md:space-y-0 md:space-x-4 md:divide-solid">
           <div className="text-center text-gray-500">
-            <p>© 2022 FAIR Data Innovations Hub.</p>
-            <p>All rights reserved.</p>
+            <p> © 2022 FAIR Data Innovations Hub. </p>
+            <p> All rights reserved. </p>
           </div>
 
           <div className=" mt-0  flex flex-row items-center justify-center">
@@ -158,7 +230,10 @@ export default function Footer() {
               href="https://vercel.com/?utm_source=fairdataihub&utm_campaign=oss"
               target="_blank"
               rel="noreferrer"
-              className="umami--click--vercel-footer mx-0 md:mx-4"
+              className="mx-0 md:mx-4"
+              data-umami-event="Navigation link"
+              data-umami-event-location="Footer"
+              data-umami-event-value="Vercel"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img

--- a/src/components/ui/navbar.tsx
+++ b/src/components/ui/navbar.tsx
@@ -166,9 +166,12 @@ export default function Navbar() {
             <Link href="/blog" passHref>
               <div
                 className={
-                  `nav-item hover-underline-animation umami--click--blog-header` +
+                  `nav-item hover-underline-animation` +
                   (router.pathname === `/blog` ? ` router-link-active ` : ` `)
                 }
+                data-umami-event="Navigation link"
+                data-umami-event-location="Header"
+                data-umami-event-value="Blog"
               >
                 Blog
               </div>
@@ -176,9 +179,12 @@ export default function Navbar() {
             <Link href="/team" passHref>
               <div
                 className={
-                  `nav-item hover-underline-animation umami--click--meet-the-team-header` +
+                  `nav-item hover-underline-animation` +
                   (router.pathname === `/team` ? ` router-link-active ` : ` `)
                 }
+                data-umami-event="Navigation link"
+                data-umami-event-location="Header"
+                data-umami-event-value="Meet the team"
               >
                 Meet The Team
               </div>
@@ -216,11 +222,14 @@ export default function Navbar() {
                       <div
                         id="soda-page"
                         className={
-                          `nav-item hover-underline-animation umami--click--soda-for-sparc-header mt-2` +
+                          `nav-item hover-underline-animation mt-2` +
                           (router.pathname === `/sodaforsparc`
                             ? ` router-link-active `
                             : ` `)
                         }
+                        data-umami-event="Navigation link"
+                        data-umami-event-location="Header"
+                        data-umami-event-value="SODA for SPARC"
                       >
                         SODA for SPARC
                       </div>
@@ -229,11 +238,14 @@ export default function Navbar() {
                       <div
                         id="aireadi-page"
                         className={
-                          `nav-item hover-underline-animation umami--click--aireadi-header mt-2 w-[200px]` +
+                          `nav-item hover-underline-animation mt-2 w-[200px]` +
                           (router.pathname === `/aireadi`
                             ? ` router-link-active `
                             : ` `)
                         }
+                        data-umami-event="Navigation link"
+                        data-umami-event-location="Header"
+                        data-umami-event-value="AI-READI"
                       >
                         AI-READI
                       </div>
@@ -242,11 +254,14 @@ export default function Navbar() {
                       <div
                         id="fairshare-page"
                         className={
-                          `nav-item hover-underline-animation umami--click--fairshare-header mt-2 w-[200px]` +
+                          `nav-item hover-underline-animation mt-2 w-[200px]` +
                           (router.pathname === `/fairshare`
                             ? ` router-link-active `
                             : ` `)
                         }
+                        data-umami-event="Navigation link"
+                        data-umami-event-location="Header"
+                        data-umami-event-value="FAIRshare"
                       >
                         FAIRshare
                       </div>
@@ -255,11 +270,14 @@ export default function Navbar() {
                       <div
                         id="knowmore-page"
                         className={
-                          `nav-item hover-underline-animation umami--click--knowmore-header mt-2` +
+                          `nav-item hover-underline-animation mt-2` +
                           (router.pathname === `/knowmore`
                             ? ` router-link-active `
                             : ` `)
                         }
+                        data-umami-event="Navigation link"
+                        data-umami-event-location="Header"
+                        data-umami-event-value="KnowMore"
                       >
                         KnowMore
                       </div>
@@ -268,11 +286,14 @@ export default function Navbar() {
                       <div
                         id="sparclink-page"
                         className={
-                          `nav-item hover-underline-animation umami--click--sparclink-header mt-2` +
+                          `nav-item hover-underline-animation mt-2` +
                           (router.pathname === `/sparclink`
                             ? ` router-link-active `
                             : ` `)
                         }
+                        data-umami-event="Navigation link"
+                        data-umami-event-location="Header"
+                        data-umami-event-value="SPARClink"
                       >
                         SPARClink
                       </div>
@@ -281,11 +302,14 @@ export default function Navbar() {
                       <div
                         id="aqua-page"
                         className={
-                          `nav-item hover-underline-animation umami--click--aqua-header mt-2` +
+                          `nav-item hover-underline-animation mt-2` +
                           (router.pathname === `/aqua`
                             ? ` router-link-active `
                             : ` `)
                         }
+                        data-umami-event="Navigation link"
+                        data-umami-event-location="Header"
+                        data-umami-event-value="AQUA"
                       >
                         AQUA
                       </div>
@@ -297,11 +321,14 @@ export default function Navbar() {
             <Link href="/contact-us" passHref>
               <div
                 className={
-                  `nav-item hover-underline-animation umami--click--contact-us-header` +
+                  `nav-item hover-underline-animation` +
                   (router.pathname === `/contact-us`
                     ? ` router-link-active `
                     : ` `)
                 }
+                data-umami-event="Navigation link"
+                data-umami-event-location="Header"
+                data-umami-event-value="Contact Us"
               >
                 Contact Us
               </div>
@@ -348,7 +375,10 @@ export default function Navbar() {
             <div className="pt-2 pb-3">
               <Link href="/blog" passHref>
                 <div
-                  className="mobile-menu umami--click--blog-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="Blog"
                   onClick={toggleMobileMenu}
                 >
                   Blog
@@ -356,7 +386,10 @@ export default function Navbar() {
               </Link>
               <Link href="/team" passHref>
                 <div
-                  className="mobile-menu umami--click--meet-the-team-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="Meet The Team"
                   onClick={toggleMobileMenu}
                 >
                   Meet The Team
@@ -364,15 +397,32 @@ export default function Navbar() {
               </Link>
               <Link href="/sodaforsparc" passHref>
                 <div
-                  className="mobile-menu umami--click--soda-for-sparc-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="SODA for SPARC"
                   onClick={toggleMobileMenu}
                 >
                   SODA for SPARC
                 </div>
               </Link>
+              <Link href="/aireadi" passHref>
+                <div
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="AI-READI"
+                  onClick={toggleMobileMenu}
+                >
+                  AI-READI
+                </div>
+              </Link>
               <Link href="/fairshare" passHref>
                 <div
-                  className="mobile-menu umami--click--fairshare-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="FAIRshare"
                   onClick={toggleMobileMenu}
                 >
                   FAIRshare
@@ -380,7 +430,10 @@ export default function Navbar() {
               </Link>
               <Link href="/knowmore" passHref>
                 <div
-                  className="mobile-menu umami--click--knowmore-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="KnowMore"
                   onClick={toggleMobileMenu}
                 >
                   KnowMore
@@ -388,7 +441,10 @@ export default function Navbar() {
               </Link>
               <Link href="/sparclink" passHref>
                 <div
-                  className="mobile-menu umami--click--sparclink-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="SPARClink"
                   onClick={toggleMobileMenu}
                 >
                   SPARClink
@@ -396,7 +452,10 @@ export default function Navbar() {
               </Link>
               <Link href="/aqua" passHref>
                 <div
-                  className="mobile-menu umami--click--aqua-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="AQUA"
                   onClick={toggleMobileMenu}
                 >
                   AQUA
@@ -404,7 +463,10 @@ export default function Navbar() {
               </Link>
               <Link href="/contact-us" passHref>
                 <div
-                  className="mobile-menu umami--click--contact-us-header z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  className="mobile-menu z-20 block cursor-pointer rounded-md px-3 py-2 text-center text-base font-medium text-black transition-all hover:bg-light-accent hover:text-white"
+                  data-umami-event="Navigation link"
+                  data-umami-event-location="Header"
+                  data-umami-event-value="Contact Us"
                   onClick={toggleMobileMenu}
                 >
                   Contact Us

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -48,17 +48,30 @@ const BlogPost: React.FC<PostProps> = ({ slug, frontMatter, postContent }) => {
   } = frontMatter;
 
   const copyLinkToClipboard = () => {
-    navigator.clipboard.writeText(`https://fairdataihub.org/blog/${slug}`);
-
-    toast.success(`Copied to clipboard succesfully.`, {
-      position: `bottom-right`,
-      autoClose: 5000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-      progress: undefined,
-    });
+    navigator.clipboard
+      .writeText(`https://fairdataihub.org/blog/${slug}`)
+      .then(() => {
+        toast.success(`Copied to clipboard succesfully.`, {
+          position: `bottom-right`,
+          autoClose: 5000,
+          hideProgressBar: false,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+        });
+      })
+      .catch((_error) => {
+        toast.error(`Failed to copy to clipboard.`, {
+          position: `bottom-right`,
+          autoClose: 5000,
+          hideProgressBar: false,
+          closeOnClick: true,
+          pauseOnHover: true,
+          draggable: true,
+          progress: undefined,
+        });
+      });
   };
 
   return (

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -175,7 +175,9 @@ const BlogPost: React.FC<PostProps> = ({ slug, frontMatter, postContent }) => {
                   </span>
                   <a
                     href={`https://twitter.com/` + authorsJSON[author].social}
-                    className="umami--click--blog-author-social text-sm font-medium text-accent"
+                    className="text-sm font-medium text-accent"
+                    data-umami-event="Blog Author Social Media"
+                    data-umami-eventvalue={authorsJSON[author].social}
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -200,7 +202,9 @@ const BlogPost: React.FC<PostProps> = ({ slug, frontMatter, postContent }) => {
               href={`http://twitter.com/share?text=I just read this article and think y'all need to take a look at this&url=https://fairdataihub.org/blog/${slug}&hashtags=FAIRData,OpenScience,OpenSource`}
               target="_blank"
               rel="noopener noreferrer"
-              className="umami--click--twitter-share-button mx-2 text-slate-500 transition-all hover:text-accent"
+              className="mx-2 text-slate-500 transition-all hover:text-accent"
+              data-umami-event="Share article"
+              data-umami-event-type="Twitter"
               aria-label="Share on Twitter"
             >
               <Icon icon="akar-icons:twitter-fill" width="20" height="20" />
@@ -209,7 +213,9 @@ const BlogPost: React.FC<PostProps> = ({ slug, frontMatter, postContent }) => {
               href={`https://www.facebook.com/sharer/sharer.php?u=https://fairdataihub.org/blog/${slug}"`}
               target="_blank"
               rel="noopener noreferrer"
-              className="umami--click--facebook-share-button mx-2 text-slate-500 transition-all hover:text-accent"
+              className="mx-2 text-slate-500 transition-all hover:text-accent"
+              data-umami-event="Share article"
+              data-umami-event-type="Facebook"
               aria-label="Share on Facebook"
             >
               <Icon icon="akar-icons:facebook-fill" width="20" height="20" />
@@ -218,7 +224,9 @@ const BlogPost: React.FC<PostProps> = ({ slug, frontMatter, postContent }) => {
               href={`https://www.linkedin.com/sharing/share-offsite/?url=https://fairdataihub.org/blog/${slug}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="umami--click--linkedin-share-button mx-2 text-slate-500 transition-all hover:text-accent"
+              className="mx-2 text-slate-500 transition-all hover:text-accent"
+              data-umami-event="Share article"
+              data-umami-event-type="LinkedIn"
               aria-label="Share on LinkedIn"
             >
               <Icon
@@ -229,7 +237,9 @@ const BlogPost: React.FC<PostProps> = ({ slug, frontMatter, postContent }) => {
             </a>
             <div
               onClick={copyLinkToClipboard}
-              className="umami--click--copy-url-button mx-2 cursor-pointer text-slate-500 transition-all hover:text-accent"
+              className="mx-2 cursor-pointer text-slate-500 transition-all hover:text-accent"
+              data-umami-event="Share article"
+              data-umami-event-type="Copy URL"
               aria-label="Copy to clipboard"
             >
               <Icon icon="akar-icons:link-chain" width="20" height="20" />

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -302,7 +302,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 // The page for each post
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const slug = (params || {}).slug;
+  const slug = params?.slug;
 
   const fileName = fs.readFileSync(`blog/${slug}.md`, `utf-8`);
   const { data: frontMatter, content: fileContent } = matter(fileName);

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -330,10 +330,8 @@ const TeamPage: React.FC<InferGetStaticPropsType<typeof getStaticProps>> = ({
               href="https://calmi2.org"
               target="_blank"
               rel="noreferrer"
-              className={
-                `text-url hover-underline-animation ` +
-                `umami--click--calmii-link`
-              }
+              className="text-url hover-underline-animation"
+              data-umami-event="Team Page - Learn more about CALMI2"
             >
               <span className="font-asap">
                 Learn more about CALMI<sup>2</sup>


### PR DESCRIPTION
This PR updates the method of event tracking. Since we have switched to Umami `v2`, events are now tracked via [data attributes](https://umami.is/docs/track-events). All the umami CSS classes have been switched out to data attributes. 