### PR TITLE
feat: ✨ added events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [2.37.0](https://github.com/fairdataihub/fairdataihub.org/compare/v2.36.3...v2.37.0) (2024-09-19)
 
-
 ### Features
 
-* ✨ add team member ([#660](https://github.com/fairdataihub/fairdataihub.org/issues/660)) ([6b383e5](https://github.com/fairdataihub/fairdataihub.org/commit/6b383e5a4b5b2fd148c45ff7b1f3afd37dd72f24)), closes [#657](https://github.com/fairdataihub/fairdataihub.org/issues/657)
+- ✨ add team member ([#660](https://github.com/fairdataihub/fairdataihub.org/issues/660)) ([6b383e5](https://github.com/fairdataihub/fairdataihub.org/commit/6b383e5a4b5b2fd148c45ff7b1f3afd37dd72f24)), closes [#657](https://github.com/fairdataihub/fairdataihub.org/issues/657)
 
 ## [2.36.3](https://github.com/fairdataihub/fairdataihub.org/compare/v2.36.2...v2.36.3) (2024-09-19)
 

--- a/events/bridge2ai-lecture.md
+++ b/events/bridge2ai-lecture.md
@@ -1,0 +1,24 @@
+---
+title: 'Introduction to AI-READI, Studying Salutogenesis in T2DM'
+startDateTime: '2024-10-10T12:00:00'
+endDateTime: '2024-10-10T15:00:00'
+heroImage: 'https://i.imgur.com/KO3ZmU4.jpeg'
+subtitle: 'This lecture, in collaboration with the Grand Challenges (GCs) at Bridge2AI, the Bridge Center Training, Recruitment, and Mentorship Working Group introduces a new education module: “Introduction to the Bridge2AI GC Datasets".'
+type: 'Lecture'
+timeZone: 'Eastern Time'
+location: 'Online'
+---
+
+## Overview
+
+In collaboration with the Grand Challenges (GCs) at Bridge2AI, the Bridge Center Training, Recruitment, and Mentorship Working Group presents a new education module launching this fall: “Introduction to the Bridge2AI GC Datasets.” Please join us on Thursday, October 10th 2024, for the first lecture in this series “Introduction to AI-READI, Studying Salutogenesis in T2DM.”Please see attached for more information. We look forward to your attendance!
+
+### Date/Time:
+
+Thursday, October 10, 2024, 12 pm - 3 pm EDT
+
+### Dial-in Information:
+
+[https://uclahs.zoom.us/j/96802224199](https://uclahs.zoom.us/j/96802224199)
+
+More information about the webinar may be found [here](https://drive.google.com/drive/u/0/folders/1LqvCyQos7w_N7is8Ux1VxFgEgckNHsMQ)!

--- a/events/bridge2ai-lecture.md
+++ b/events/bridge2ai-lecture.md
@@ -5,7 +5,7 @@ endDateTime: '2024-10-10T15:00:00'
 heroImage: 'https://i.imgur.com/KO3ZmU4.jpeg'
 subtitle: 'This lecture, in collaboration with the Grand Challenges (GCs) at Bridge2AI, the Bridge Center Training, Recruitment, and Mentorship Working Group introduces a new education module: “Introduction to the Bridge2AI GC Datasets".'
 type: 'Lecture'
-timeZone: 'Eastern Time'
+timeZone: 'America/New_York'
 location: 'Online'
 ---
 

--- a/events/dknet-webinar.md
+++ b/events/dknet-webinar.md
@@ -1,0 +1,36 @@
+---
+title: 'Introduction to AI-READI, Studying Salutogenesis in T2DM'
+startDateTime: '2024-10-11T11:00:00'
+endDateTime: '2024-10-11T12:00:00'
+heroImage: 'https://i.imgur.com/CNG6e01.jpeg'
+subtitle: 'This webinar will introduce the AI-READI project, present the dataset, show how to request it, and explore research questions for machine learning, such as predicting health improvement in T2DM, understanding disease progression, and investigating risk factors.'
+type: 'Webinar '
+timeZone: 'America/Los_Angeles'
+location: 'Online'
+---
+
+## Presenters:
+
+- [Cecilia Lee](https://aireadi.org/team#Cecilia-Lee), MD, MS. Professor, Klorfine Family Endowed Chair of Ophthalmology, University of Washington
+- [Bhavesh Patel](https://aireadi.org/team#Bhavesh-Patel), PhD. Research Professor, California Medical Innovations Institute
+- [Sally L. Baxter](https://aireadi.org/team#Sally-Baxter), MD, MSc. Associate Professor of Ophthalmology and Biomedical Informatics, University of California San Diego
+
+## Overview
+
+The AI-READI (Artificial Intelligence Ready and Equitable Atlas for Diabetes Insights, [https://aireadi.org](https://aireadi.org)) project, funded by the NIH Common Fund’s Bridge2AI Program, aims to develop a multimodal dataset specifically designed to be AI-ready for the study of salutogenesis in Type 2 Diabetes Mellitus (T2DM). Despite advancements in diabetes care, limited knowledge exists on how individuals with T2DM may revert to health. AI-READI team is building this dataset from a diverse cohort of 4,000 participants, ensuring it is structured for immediate use in machine learning algorithm training and analysis. The project emphasizes ethical and equitable data collection, adherence to FAIR (Findable, Accessible, Interoperable, Reusable) data principles, and establishing best practices for data sharing and management. By focusing on AI-readiness, the dataset will enable rapid application of machine learning to uncover novel insights into effective treatment strategies.
+
+### The top 3 key questions that Bridge2AI AI-READI datasets can answer:
+
+1.  How can we better understand Type 2 Diabetes (T2DM) heterogeneity? <br/>
+2.  What are the connections between multi-organ function in T2DM, and how are the kidney, heart, eye, brain interlinked? <br/>
+3.  How do interactions between environmental factors (e.g. air pollution) drive outcomes in T2DM?
+
+### Date/Time:
+
+Friday, October 11, 2024, 11 am - 12 pm PT
+
+### Dial-in Information:
+
+[https://uchealth.zoom.us/meeting/register/tZEsdOmqqDgiEtes2c8OVfCoFPZlZ2vxi6Hx](https://uchealth.zoom.us/meeting/register/tZEsdOmqqDgiEtes2c8OVfCoFPZlZ2vxi6Hx).
+
+More information about the webinar may be found [here](https://dknet.org/about/blog/2776)!


### PR DESCRIPTION
## Summary by Sourcery

Add two new events related to the AI-READI project: a webinar and a lecture, both focusing on the study of salutogenesis in Type 2 Diabetes Mellitus and the introduction of the AI-READI dataset.

New Features:
- Add a new webinar event titled 'Introduction to AI-READI, Studying Salutogenesis in T2DM' scheduled for October 11, 2024, focusing on the AI-READI project and its dataset for Type 2 Diabetes Mellitus research.
- Introduce a new lecture event titled 'Introduction to AI-READI, Studying Salutogenesis in T2DM' as part of the Bridge2AI Grand Challenges series, scheduled for October 10, 2024.