### PR TITLE
fix: 🐛 edit & add headers on Impact page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # [2.38.0](https://github.com/fairdataihub/fairdataihub.org/compare/v2.37.0...v2.38.0) (2024-10-09)
 
-
 ### Features
 
-* ✨ added events ([#662](https://github.com/fairdataihub/fairdataihub.org/issues/662)) ([70bdb55](https://github.com/fairdataihub/fairdataihub.org/commit/70bdb55b2d5ff21531dc2be9659b2cc4504cdab0))
+- ✨ added events ([#662](https://github.com/fairdataihub/fairdataihub.org/issues/662)) ([70bdb55](https://github.com/fairdataihub/fairdataihub.org/commit/70bdb55b2d5ff21531dc2be9659b2cc4504cdab0))
 
 # [2.37.0](https://github.com/fairdataihub/fairdataihub.org/compare/v2.36.3...v2.37.0) (2024-09-19)
 

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -5,7 +5,7 @@
     "title": "SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data",
     "subtitle": "",
     "citation": "Bandrowski, A., Grethe, J. S., Pilko, A., Gillespie, T., Pine, G., Patel, B., Surles-Zeigler, M., & Martone, M. E. (2021). SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.02.10.430563",
-    "type": "Preprint"
+    "type": "Preprints"
   },
   {
     "project": ["sodaforsparc"],
@@ -21,7 +21,7 @@
     "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
     "subtitle": "",
     "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Scientific Data, 10(1). https://doi.org/10.1038/s41597-023-02463-x",
-    "type": "Journal Article"
+    "type": "Journal Articles"
   },
   {
     "project": ["fairshare"],
@@ -29,7 +29,7 @@
     "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
     "subtitle": "",
     "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2022). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2022.04.18.488694",
-    "type": "Preprint"
+    "type": "Preprints"
   },
   {
     "project": ["fairshare"],
@@ -37,7 +37,7 @@
     "title": "Making biomedical research software FAIR with FAIRshare",
     "subtitle": "Poster presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
     "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software FAIR with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119054.1",
-    "type": "Poster"
+    "type": "Posters"
   },
   {
     "project": ["fairbiors"],
@@ -45,7 +45,7 @@
     "title": "FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR",
     "subtitle": "Poster presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
     "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR. F1000 Research Limited. https://doi.org/10.7490/f1000research.1119608.1",
-    "type": "Poster"
+    "type": "Posters"
   },
   {
     "project": ["fairshare"],
@@ -53,7 +53,7 @@
     "title": "Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare",
     "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
     "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
-    "type": "Conference Presentation"
+    "type": "Conference Presentations"
   },
   {
     "project": ["fairbiors"],
@@ -61,7 +61,7 @@
     "title": "FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR",
     "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
     "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR. F1000 Research Limited. https://doi.org/10.7490/f1000research.1119609.1",
-    "type": "Conference Presentation"
+    "type": "Conference Presentations"
   },
   {
     "project": ["knowmore"],
@@ -69,7 +69,7 @@
     "title": "KnowMore: An Automated Knowledge Discovery Tool for the FAIR SPARC Datasets",
     "subtitle": "",
     "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.08.08.455581",
-    "type": "Preprint"
+    "type": "Preprints"
   },
   {
     "project": ["aqua"],
@@ -77,7 +77,7 @@
     "title": "AQUA: an Advanced QUery Architecture for the SPARC Portal",
     "subtitle": "",
     "citation": "Shahidi, N., Lin, X., Munarko, Y., Rasmy, L., & Ngo, T. (2021). AQUA: an Advanced QUery Architecture for the SPARC Portal. F1000Research, 10, 930. https://doi.org/10.12688/f1000research.73018.1",
-    "type": "Journal Article"
+    "type": "Journal Articles"
   },
   {
     "project": ["sparclink"],
@@ -85,7 +85,7 @@
     "title": "SPARClink: an interactive tool to visualize the impact of the SPARC program",
     "subtitle": "",
     "citation": "Soundarajan, S., Kuruppu, S., Singh, A., Kim, J., & Achalla, M. (2022). SPARClink: an interactive tool to visualize the impact of the SPARC program. F1000Research, 11, 124. https://doi.org/10.12688/f1000research.75071.1",
-    "type": "Journal Article"
+    "type": "Journal Articles"
   },
   {
     "project": ["aireadi"],
@@ -93,7 +93,7 @@
     "title": "Software Development Best Practices of the AI-READI Project",
     "subtitle": "",
     "citation": "Patel, B., Soundarajan, S., McWeeney, S., Cordier, B. A., & Benton, E. S. (2022). Software Development Best Practices of the AI-READI Project (v1.0.0). Zenodo. https://doi.org/10.5281/ZENODO.7363102",
-    "type": "Report"
+    "type": "Reports"
   },
   {
     "project": ["aireadi"],
@@ -101,7 +101,7 @@
     "title": "AI-READI Code of Conduct",
     "subtitle": "",
     "citation": "Lee, A., Owen, J., Patel, B., Nebeker, C., Lee, C., Zangwill, L., Hurst, S., Singer, S., Li-Pook-Than, J., & Matthews, D. (2023). AI-READI Code of Conduct (1.0). Zenodo. https://doi.org/10.5281/ZENODO.7641650",
-    "type": "Report"
+    "type": "Reports"
   },
   {
     "project": ["aireadi"],
@@ -109,7 +109,7 @@
     "title": "AI-READI Steering Committee Charter",
     "subtitle": "",
     "citation": "Lee, A., Owen, J., Patel, B., Nebeker, C., Lee, C., Zangwill, L., Hurst, S., & Singer, S. (2023). AI-READI Steering Committee Charter (1.0). Zenodo. https://doi.org/10.5281/ZENODO.7641684",
-    "type": "Report"
+    "type": "Reports"
   },
   {
     "project": ["sodaforsparc"],
@@ -117,7 +117,7 @@
     "title": "Sharing is Caring - Making SPARC data FAIR with SODA",
     "subtitle": "",
     "citation": "SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data. (2021). SPARC. https://sparc.science/news-and-events/community-spotlight/success-stories/sharing-is-caring-making-sparc-data-fair-with-soda",
-    "type": "Web Article"
+    "type": "Web Articles"
   },
   {
     "project": ["sodaforsparc"],
@@ -173,7 +173,7 @@
     "title": "Codefair: Make biomedical research software FAIR without breaking a sweat",
     "subtitle": "Slides presented at Bioinformatics Open Source Conference (BOSC), 2024",
     "citation": "Portillo D, Soundarajan S, Clark J and Patel B. Codefair: Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:912",
-    "type": "Conference Presentation"
+    "type": "Conference Presentations"
   },
   {
     "project": ["codefair"],
@@ -181,13 +181,13 @@
     "title": "Codefair - Make biomedical research software FAIR without breaking a sweat",
     "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
     "citation": "Portillo D, Soundarajan S, Clark J and Patel B. Codefair - Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:911",
-    "type": "Poster"
+    "type": "Posters"
   },
   {
     "title": "SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data",
     "url": "https://doi.org/10.21105/joss.06140",
     "project": ["sodaforsparc"],
     "citation": "Marroquin et al., (2024). SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data. Journal of Open Source Software, 9(100), 6140, https://doi.org/10.21105/joss.06140",
-    "type": "Journal Article"
+    "type": "Journal Articles"
   }
 ]

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -71,13 +71,12 @@
     "citation": "Shahidi, N., Lin, X., Munarko, Y., Rasmy, L., & Ngo, T. (2021). AQUA: an Advanced QUery Architecture for the SPARC Portal. F1000Research, 10, 930. https://doi.org/10.12688/f1000research.73018.1",
     "type": "Journal Articles"
   },
-
   {
     "project": ["aireadi"],
     "url": "https://doi.org/10.5281/zenodo.13984769",
     "title": "Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster)",
     "subtitle": "",
-    "citation": "Patel, Bhavesh, Soundarajan, Sanjay,Gasimova, Aydan, Gim, Nayoon, Shaffer, Jamie, & Lee, Aaron. (2024). Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984769",
+    "citation": "Patel, B., Soundarajan, S.,Gasimova, A., Gim, N., Shaffer,J., & Lee, A. (2024). Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984769",
     "type": "Posters"
   },
   {
@@ -85,7 +84,7 @@
     "url": "https://doi.org/10.5281/zenodo.13948350",
     "title": "Codefair - Your Personal Assistant for Developing FAIR Software (Poster)",
     "subtitle": "",
-    "citation": "Portillo, Dorian, Soundarajan, Sanjay, Clark, Jacob, Patel, Bhavesh. (2024). Codefair - Your Personal Assistant for Developing FAIR Software (Poster) (1.0.0). Zenodo. https://zenodo.org/records/13948350",
+    "citation": "Portillo, D, Soundarajan, S, Clark, J and Patel, B. (2024). Codefair - Your Personal Assistant for Developing FAIR Software (Poster) (1.0.0). Zenodo. https://zenodo.org/records/13948350",
     "type": "Posters"
   },
   {
@@ -93,7 +92,7 @@
     "url": "https://doi.org/10.7490/f1000research.1119823.1",
     "title": "Codefair - Make biomedical research software FAIR without breaking a sweat",
     "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
-    "citation": "Portillo D, Soundarajan S, Clark J and Patel B. Codefair - Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:911",
+    "citation": "Portillo, D, Soundarajan, S, Clark, J and Patel, B. Codefair - Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:911",
     "type": "Posters"
   },
   {
@@ -109,7 +108,7 @@
     "url": "https://doi.org/10.7490/f1000research.1119054.1",
     "title": "Making biomedical research software FAIR with FAIRshare",
     "subtitle": "Poster presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
-    "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software FAIR with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119054.1",
+    "citation": "Patel, B., & Soundarajan, S. (2022). Making biomedical research software FAIR with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119054.1",
     "type": "Posters"
   },
   {
@@ -117,7 +116,7 @@
     "url": "https://doi.org/10.5281/zenodo.13984710",
     "title": "Introduction to AI-READI, Studying Salutogenesis in T2DM (dkNET Presentation)",
     "subtitle": "",
-    "citation": "Lee, Cecilia, Patel, Bhavesh, & Baxter, Sally. (2024). Introduction to AI-READI, Studying Salutogenesis in T2DM (dkNET Presentation) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984710",
+    "citation": "Lee, C., Patel, B., & Baxter, S. (2024). Introduction to AI-READI, Studying Salutogenesis in T2DM (dkNET Presentation) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984710",
     "type": "Webinars/Lectures"
   },
   {
@@ -125,7 +124,7 @@
     "url": "https://doi.org/10.5281/zenodo.13984755",
     "title": "Introduction to AI-READI, Studying Salutogenesis in T2DM (Bridge2AI Lecture Series)",
     "subtitle": "",
-    "citation": "Lee, Cecilia, Patel, Bhavesh, & Baxter, Sally. (2024). Introduction to AI-READI, Studying Salutogenesis in T2DM (Bridge2AI Lecture Series) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984755",
+    "citation": "Lee, C., Patel, B., & Baxter, S. (2024). Introduction to AI-READI, Studying Salutogenesis in T2DM (Bridge2AI Lecture Series) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984755",
     "type": "Webinars/Lectures"
   },
   {
@@ -166,7 +165,7 @@
     "url": "https://doi.org/10.7490/f1000research.1119055.1",
     "title": "Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare",
     "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
-    "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
+    "citation": "Patel, B., & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
     "type": "Conference Presentations"
   },
 
@@ -175,7 +174,7 @@
     "url": "https://zenodo.org/records/13328255",
     "title": "AI-READI Code of Conduct",
     "subtitle": "",
-    "citation": "Lee, Aaron, Owen, Julia, Patel, Bhavesh, Nebeker, Camille, Lee, Cecilia, Zangwill, Linda, Hurst, Samm, Singer, Sara, Li-Pook-Than, Jennifer, & Matthews, Debra. (2024). AI-READI Code of Conduct (2.0). Zenodo. https://zenodo.org/records/13328255",
+    "citation": "Lee, A., Owen, J., Patel, B., Nebeker, C., Lee, C., Zangwill, L., Hurst, S., Singer, S., Li-Pook-Than, J., & Matthews, D. (2024). AI-READI Code of Conduct (2.0). Zenodo. https://zenodo.org/records/13328255",
     "type": "Reports"
   },
   {
@@ -183,7 +182,7 @@
     "url": "https://doi.org/10.5281/zenodo.10642459",
     "title": "License terms for reusing the AI-READI dataset",
     "subtitle": "",
-    "citation": "Contreras, Jorge, Evans, Barbara, Hurst, Samm, Patel, Bhavesh, Mcweeney, Shannon, Lee, Cecilia, & Lee, Aaron (2024).License terms for reusing the AI-READI dataset (1.0). Zenodo. https://doi.org/10.5281/zenodo.10642459",
+    "citation": "Contreras, J., Evans, B., Hurst, S., Patel, B., Mcweeney, S., Lee, C., & Lee, A. (2024). License terms for reusing the AI-READI dataset (1.0). Zenodo. https://doi.org/10.5281/zenodo.10642459",
     "type": "Reports"
   },
   {
@@ -191,7 +190,7 @@
     "url": "https://doi.org/10.5281/zenodo.7641684",
     "title": "AI-READI Steering Committee Charter",
     "subtitle": "",
-    "citation": "Lee, Aaron, Owen, Julia, Patel, Bhavesh, Nebeker, Camille, Lee, Cecilia, Zangwill, Linda, Hurst, Samm, & Singer, Sara. (2023). AI-READI Steering Committee Charter (1.0). Zenodo. https://doi.org/10.5281/zenodo.7641684",
+    "citation": "Lee, A., Owen, J., Patel, B., Nebeker, C., Lee, C., Zangwill, L., Hurst, S., & Singer, S. (2023). AI-READI Steering Committee Charter (1.0). Zenodo. https://doi.org/10.5281/zenodo.7641684",
     "type": "Reports"
   },
   {
@@ -199,7 +198,7 @@
     "url": "https://doi.org/10.5281/zenodo.7363102",
     "title": "Software Development Best Practices of the AI-READI Project",
     "subtitle": "",
-    "citation": "Patel, Bhavesh, Soundarajan, Sanjay, McWeeney, Shannon, Cordier, Benjamin A., & Benton, Erik S. (2022). Software Development Best Practices of the AI-READI Project (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.7363102",
+    "citation": "Patel, B., Soundarajan, S., McWeeney, S., Cordier, B. A., & Benton, E. S. (2022). Software Development Best Practices of the AI-READI Project (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.7363102",
     "type": "Reports"
   },
   {

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -1,5 +1,4 @@
 [
-
   {
     "url": "https://doi.org/10.1101/2024.07.29.24310315",
     "title": "Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data",
@@ -168,8 +167,6 @@
     "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
     "type": "Conference Presentations"
   },
-
-
 
   {
     "project": ["aireadi"],

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -1,5 +1,6 @@
 [
   {
+    "project": ["aireadi"],
     "url": "https://doi.org/10.1101/2024.07.29.24310315",
     "title": "Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data",
     "subtitle": "",
@@ -40,9 +41,9 @@
     "type": "Abstract"
   },
   {
+    "project": ["sodaforsparc"],
     "title": "SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data",
     "url": "https://doi.org/10.21105/joss.06140",
-    "project": ["sodaforsparc"],
     "citation": "Marroquin et al., (2024). SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data. Journal of Open Source Software, 9(100), 6140, https://doi.org/10.21105/joss.06140",
     "type": "Journal Articles"
   },
@@ -136,6 +137,7 @@
     "type": "Conference Presentations"
   },
   {
+    "project": [],
     "url": "https://zenodo.org/records/13159874",
     "title": "Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024)",
     "subtitle": "",

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -35,7 +35,7 @@
     "url": "https://doi.org/10.1101/2024.07.29.24310315",
     "title": "Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data",
     "subtitle": "",
-    "citation": "Alavi, A., Cha, K., Esfarjani, D. P., Patel, B., Than, J. L. P., Lee, A. Y., ... & Bahmani, A. (2024). Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data. medRxiv, 2024-07.https://doi.org/10.1101/2024.07.29.24310315",
+    "citation": "Alavi, A., Cha, K., Esfarjani, D. P., Patel, B., Than, J. L. P., Lee, A. Y., ... & Bahmani, A. (2024). Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data. MedRxiv. https://doi.org/10.1101/2024.07.29.24310315",
     "type": "Preprints"
   },
   {
@@ -43,7 +43,7 @@
     "url": "https://doi.org/10.1101/2022.04.18.488694",
     "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
     "subtitle": "",
-    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2022). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2022.04.18.488694",
+    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2022). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Cold Spring Harbor Laboratory. BioRxiv. https://doi.org/10.1101/2022.04.18.488694",
     "type": "Preprints"
   },
   {
@@ -51,16 +51,15 @@
     "url": "https://doi.org/10.1101/2021.02.10.430563",
     "title": "SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data",
     "subtitle": "",
-    "citation": "Bandrowski, A., Grethe, J. S., Pilko, A., Gillespie, T., Pine, G., Patel, B., Surles-Zeigler, M., & Martone, M. E. (2021). SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.02.10.430563",
+    "citation": "Bandrowski, A., Grethe, J. S., Pilko, A., Gillespie, T., Pine, G., Patel, B., Surles-Zeigler, M., & Martone, M. E. (2021). SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data. Cold Spring Harbor Laboratory. BioRxiv. https://doi.org/10.1101/2021.02.10.430563",
     "type": "Preprints"
   },
-
   {
     "project": ["knowmore"],
     "url": "https://doi.org/10.1101/2021.08.08.455581",
     "title": "KnowMore: An Automated Knowledge Discovery Tool for the FAIR SPARC Datasets",
     "subtitle": "",
-    "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.08.08.455581",
+    "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. BioRxiv. https://doi.org/10.1101/2021.08.08.455581",
     "type": "Preprints"
   },
     {
@@ -90,7 +89,7 @@
   {
     "project": ["aireadi"],
     "url": "https://github.com/AI-READI/pyfairdatatools",
-    "title": "pyfairdatatools",
+    "title": "Pyfairdatatools",
     "subtitle": "",
     "citation": "pyfairdatatools. (started 2022). https://github.com/AI-READI/pyfairdatatools (Development status: Active)",
     "type": "Software"
@@ -116,7 +115,7 @@
     "url": "https://github.com/fairdataihub/SODA-for-SPARC",
     "title": "SODA (Software to Organize Data Automatically) for SPARC",
     "subtitle": "",
-    "citation": "SODA for SPARC. (started 2019). https://github.com/fairdataihub/SODA-for-SPARC (Development status: Active)",
+    "citation": "SODA. (started 2019). https://github.com/fairdataihub/SODA-for-SPARC (Development status: Active)",
     "type": "Software"
   },
   {
@@ -148,7 +147,7 @@
     "url": "https://doi.org/10.7490/f1000research.1119824.1",
     "title": "Codefair: Make biomedical research software FAIR without breaking a sweat",
     "subtitle": "Slides presented at Bioinformatics Open Source Conference (BOSC), 2024",
-    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. Codefair: Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:912",
+    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. (2024). Codefair: Make biomedical research software FAIR without breaking a sweat (13:912). F1000 Research. https://doi.org/10.7490/f1000research.1119824.1",
     "type": "Conference Presentations"
   },
 
@@ -181,7 +180,7 @@
     "url": "https://doi.org/10.5281/zenodo.13948350",
     "title": "Codefair - Your Personal Assistant for Developing FAIR Software (Poster)",
     "subtitle": "",
-    "citation": "Portillo, D, Soundarajan, S, Clark, J and Patel, B. (2024). Codefair - Your Personal Assistant for Developing FAIR Software (Poster) (1.0.0). Zenodo. https://zenodo.org/records/13948350",
+    "citation": "Portillo, D, Soundarajan, S, Clark, J & Patel, B. (2024). Codefair - Your Personal Assistant for Developing FAIR Software (Poster) (1.0.0). Zenodo. https://zenodo.org/records/13948350",
     "type": "Posters"
   },
   {
@@ -189,7 +188,7 @@
     "url": "https://doi.org/10.7490/f1000research.1119823.1",
     "title": "Codefair - Make biomedical research software FAIR without breaking a sweat",
     "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
-    "citation": "Portillo, D, Soundarajan, S, Clark, J and Patel, B. Codefair - Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:911",
+    "citation": "Portillo, D, Soundarajan, S, Clark, J & Patel, B. (2024). Codefair - Make biomedical research software FAIR without breaking a sweat (13:911). F1000Research. https://doi.org/10.7490/f1000research.1119823.1",
     "type": "Posters"
   },
   {

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -75,7 +75,7 @@
     "url": "https://github.com/AI-READI/fairhub-app",
     "title": "FAIRhub Study Management Platform",
     "subtitle": "",
-    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-app (Development status: Active)",
+    "citation": "FAIRhub study management platform. (started 2022). https://github.com/AI-READI/fairhub-app (Development status: Active)",
     "type": "Software"
   },
   {
@@ -83,7 +83,7 @@
     "url": "https://github.com/AI-READI/fairhub-portal",
     "title": "FAIRhub Data Portal",
     "subtitle": "",
-    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-portal (Development status: Active)",
+    "citation": "FAIRhub data portal. (started 2022). https://github.com/AI-READI/fairhub-portal (Development status: Active)",
     "type": "Software"
   },
   {
@@ -172,7 +172,7 @@
     "url": "https://doi.org/10.5281/zenodo.13984769",
     "title": "Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster)",
     "subtitle": "",
-    "citation": "Patel, B., Soundarajan, S.,Gasimova, A., Gim, N., Shaffer,J., & Lee, A. (2024). Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984769",
+    "citation": "Patel, B., Soundarajan, S., Gasimova, A., Gim, N., Shaffer, J., & Lee, A. (2024). Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984769",
     "type": "Posters"
   },
   {

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -35,7 +35,7 @@
     "url": "https://doi.org/10.1101/2024.07.29.24310315",
     "title": "Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data",
     "subtitle": "",
-    "citation": "Alavi, A., Cha, K., Esfarjani, D. P., Patel, B., Than, J. L. P., Lee, A. Y., ... & Bahmani, A. (2024). Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data. MedRxiv. https://doi.org/10.1101/2024.07.29.24310315",
+    "citation": "Alavi, A., Cha, K., Esfarjani, D. P., Patel, B., Than, J. L. P., Lee, A. Y., Nebeker, C., Snyder, M. & Bahmani, A. (2024). Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data. MedRxiv. https://doi.org/10.1101/2024.07.29.24310315",
     "type": "Preprints"
   },
   {

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -62,7 +62,7 @@
     "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. BioRxiv. https://doi.org/10.1101/2021.08.08.455581",
     "type": "Preprints"
   },
-    {
+  {
     "project": ["codefair"],
     "url": "https://github.com/fairdataihub/codefair-app",
     "title": "Codefair",

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -1,10 +1,35 @@
 [
+
+  {
+    "url": "https://doi.org/10.1101/2024.07.29.24310315",
+    "title": "Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data",
+    "subtitle": "",
+    "citation": "Alavi, A., Cha, K., Esfarjani, D. P., Patel, B., Than, J. L. P., Lee, A. Y., ... & Bahmani, A. (2024). Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data. medRxiv, 2024-07.https://doi.org/10.1101/2024.07.29.24310315",
+    "type": "Preprints"
+  },
+  {
+    "project": ["fairshare"],
+    "url": "https://doi.org/10.1101/2022.04.18.488694",
+    "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
+    "subtitle": "",
+    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2022). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2022.04.18.488694",
+    "type": "Preprints"
+  },
   {
     "project": ["sodaforsparc"],
     "url": "https://doi.org/10.1101/2021.02.10.430563",
     "title": "SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data",
     "subtitle": "",
     "citation": "Bandrowski, A., Grethe, J. S., Pilko, A., Gillespie, T., Pine, G., Patel, B., Surles-Zeigler, M., & Martone, M. E. (2021). SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.02.10.430563",
+    "type": "Preprints"
+  },
+
+  {
+    "project": ["knowmore"],
+    "url": "https://doi.org/10.1101/2021.08.08.455581",
+    "title": "KnowMore: An Automated Knowledge Discovery Tool for the FAIR SPARC Datasets",
+    "subtitle": "",
+    "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.08.08.455581",
     "type": "Preprints"
   },
   {
@@ -16,6 +41,13 @@
     "type": "Abstract"
   },
   {
+    "title": "SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data",
+    "url": "https://doi.org/10.21105/joss.06140",
+    "project": ["sodaforsparc"],
+    "citation": "Marroquin et al., (2024). SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data. Journal of Open Source Software, 9(100), 6140, https://doi.org/10.21105/joss.06140",
+    "type": "Journal Articles"
+  },
+  {
     "project": ["fairshare", "fairbiors"],
     "url": "https://doi.org/10.1038/s41597-023-02463-x",
     "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
@@ -24,19 +56,44 @@
     "type": "Journal Articles"
   },
   {
-    "project": ["fairshare"],
-    "url": "https://doi.org/10.1101/2022.04.18.488694",
-    "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
+    "project": ["sparclink"],
+    "url": "https://doi.org/10.12688/f1000research.75071.1",
+    "title": "SPARClink: an interactive tool to visualize the impact of the SPARC program",
     "subtitle": "",
-    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2022). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2022.04.18.488694",
-    "type": "Preprints"
+    "citation": "Soundarajan, S., Kuruppu, S., Singh, A., Kim, J., & Achalla, M. (2022). SPARClink: an interactive tool to visualize the impact of the SPARC program. F1000Research, 11, 124. https://doi.org/10.12688/f1000research.75071.1",
+    "type": "Journal Articles"
   },
   {
-    "project": ["fairshare"],
-    "url": "https://doi.org/10.7490/f1000research.1119054.1",
-    "title": "Making biomedical research software FAIR with FAIRshare",
-    "subtitle": "Poster presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
-    "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software FAIR with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119054.1",
+    "project": ["aqua"],
+    "url": "https://doi.org/10.12688/f1000research.73018.1",
+    "title": "AQUA: an Advanced QUery Architecture for the SPARC Portal",
+    "subtitle": "",
+    "citation": "Shahidi, N., Lin, X., Munarko, Y., Rasmy, L., & Ngo, T. (2021). AQUA: an Advanced QUery Architecture for the SPARC Portal. F1000Research, 10, 930. https://doi.org/10.12688/f1000research.73018.1",
+    "type": "Journal Articles"
+  },
+
+  {
+    "project": ["aireadi"],
+    "url": "https://doi.org/10.5281/zenodo.13984769",
+    "title": "Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster)",
+    "subtitle": "",
+    "citation": "Patel, Bhavesh, Soundarajan, Sanjay,Gasimova, Aydan, Gim, Nayoon, Shaffer, Jamie, & Lee, Aaron. (2024). Clinical Dataset Structure: A Universal Standard for Structuring Clinical Research Data and Metadata (Poster) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984769",
+    "type": "Posters"
+  },
+  {
+    "project": ["codefair"],
+    "url": "https://doi.org/10.5281/zenodo.13948350",
+    "title": "Codefair - Your Personal Assistant for Developing FAIR Software (Poster)",
+    "subtitle": "",
+    "citation": "Portillo, Dorian, Soundarajan, Sanjay, Clark, Jacob, Patel, Bhavesh. (2024). Codefair - Your Personal Assistant for Developing FAIR Software (Poster) (1.0.0). Zenodo. https://zenodo.org/records/13948350",
+    "type": "Posters"
+  },
+  {
+    "project": ["codefair"],
+    "url": "https://doi.org/10.7490/f1000research.1119823.1",
+    "title": "Codefair - Make biomedical research software FAIR without breaking a sweat",
+    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
+    "citation": "Portillo D, Soundarajan S, Clark J and Patel B. Codefair - Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:911",
     "type": "Posters"
   },
   {
@@ -49,12 +106,52 @@
   },
   {
     "project": ["fairshare"],
-    "url": "https://doi.org/10.7490/f1000research.1119055.1",
-    "title": "Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare",
-    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
-    "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
+    "url": "https://doi.org/10.7490/f1000research.1119054.1",
+    "title": "Making biomedical research software FAIR with FAIRshare",
+    "subtitle": "Poster presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
+    "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software FAIR with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119054.1",
+    "type": "Posters"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://doi.org/10.5281/zenodo.13984710",
+    "title": "Introduction to AI-READI, Studying Salutogenesis in T2DM (dkNET Presentation)",
+    "subtitle": "",
+    "citation": "Lee, Cecilia, Patel, Bhavesh, & Baxter, Sally. (2024). Introduction to AI-READI, Studying Salutogenesis in T2DM (dkNET Presentation) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984710",
+    "type": "Webinars/Lectures"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://doi.org/10.5281/zenodo.13984755",
+    "title": "Introduction to AI-READI, Studying Salutogenesis in T2DM (Bridge2AI Lecture Series)",
+    "subtitle": "",
+    "citation": "Lee, Cecilia, Patel, Bhavesh, & Baxter, Sally. (2024). Introduction to AI-READI, Studying Salutogenesis in T2DM (Bridge2AI Lecture Series) (1.0.0). Zenodo. https://doi.org/10.5281/zenodo.13984755",
+    "type": "Webinars/Lectures"
+  },
+  {
+    "project": ["codefair"],
+    "url": "https://zenodo.org/records/13948381",
+    "title": "Codefair: Your Personal Assistant for Developing FAIR Software (Presentation)",
+    "subtitle": "",
+    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. (2024). Codefair: Your Personal Assistant for Developing FAIR Software (Presentation) (1.0.0). Zenodo. https://zenodo.org/records/13948381",
     "type": "Conference Presentations"
   },
+  {
+    "url": "https://zenodo.org/records/13159874",
+    "title": "Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024)",
+    "subtitle": "",
+    "citation": "Patel, B. (2024). Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024) (1.0.0). Zenodo. https://zenodo.org/records/13159874",
+    "type": "Conference Presentations"
+  },
+  {
+    "project": ["codefair"],
+    "url": "https://doi.org/10.7490/f1000research.1119824.1",
+    "title": "Codefair: Make biomedical research software FAIR without breaking a sweat",
+    "subtitle": "Slides presented at Bioinformatics Open Source Conference (BOSC), 2024",
+    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. Codefair: Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:912",
+    "type": "Conference Presentations"
+  },
+
   {
     "project": ["fairbiors"],
     "url": "https://doi.org/10.7490/f1000research.1119609.1",
@@ -64,43 +161,30 @@
     "type": "Conference Presentations"
   },
   {
-    "project": ["knowmore"],
-    "url": "https://doi.org/10.1101/2021.08.08.455581",
-    "title": "KnowMore: An Automated Knowledge Discovery Tool for the FAIR SPARC Datasets",
-    "subtitle": "",
-    "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.08.08.455581",
-    "type": "Preprints"
+    "project": ["fairshare"],
+    "url": "https://doi.org/10.7490/f1000research.1119055.1",
+    "title": "Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare",
+    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
+    "citation": "Bhavesh Patel, & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
+    "type": "Conference Presentations"
   },
-  {
-    "project": ["aqua"],
-    "url": "https://doi.org/10.12688/f1000research.73018.1",
-    "title": "AQUA: an Advanced QUery Architecture for the SPARC Portal",
-    "subtitle": "",
-    "citation": "Shahidi, N., Lin, X., Munarko, Y., Rasmy, L., & Ngo, T. (2021). AQUA: an Advanced QUery Architecture for the SPARC Portal. F1000Research, 10, 930. https://doi.org/10.12688/f1000research.73018.1",
-    "type": "Journal Articles"
-  },
-  {
-    "project": ["sparclink"],
-    "url": "https://doi.org/10.12688/f1000research.75071.1",
-    "title": "SPARClink: an interactive tool to visualize the impact of the SPARC program",
-    "subtitle": "",
-    "citation": "Soundarajan, S., Kuruppu, S., Singh, A., Kim, J., & Achalla, M. (2022). SPARClink: an interactive tool to visualize the impact of the SPARC program. F1000Research, 11, 124. https://doi.org/10.12688/f1000research.75071.1",
-    "type": "Journal Articles"
-  },
+
+
+
   {
     "project": ["aireadi"],
-    "url": "https://doi.org/10.5281/zenodo.7363102",
-    "title": "Software Development Best Practices of the AI-READI Project",
+    "url": "https://zenodo.org/records/13328255",
+    "title": "AI-READI Code of Conduct",
     "subtitle": "",
-    "citation": "Patel, B., Soundarajan, S., McWeeney, S., Cordier, B. A., & Benton, E. S. (2022). Software Development Best Practices of the AI-READI Project (v1.0.0). Zenodo. https://doi.org/10.5281/ZENODO.7363102",
+    "citation": "Lee, Aaron, Owen, Julia, Patel, Bhavesh, Nebeker, Camille, Lee, Cecilia, Zangwill, Linda, Hurst, Samm, Singer, Sara, Li-Pook-Than, Jennifer, & Matthews, Debra. (2024). AI-READI Code of Conduct (2.0). Zenodo. https://zenodo.org/records/13328255",
     "type": "Reports"
   },
   {
     "project": ["aireadi"],
-    "url": "https://doi.org/10.5281/zenodo.7641650",
-    "title": "AI-READI Code of Conduct",
+    "url": "https://doi.org/10.5281/zenodo.10642459",
+    "title": "License terms for reusing the AI-READI dataset",
     "subtitle": "",
-    "citation": "Lee, A., Owen, J., Patel, B., Nebeker, C., Lee, C., Zangwill, L., Hurst, S., Singer, S., Li-Pook-Than, J., & Matthews, D. (2023). AI-READI Code of Conduct (1.0). Zenodo. https://doi.org/10.5281/ZENODO.7641650",
+    "citation": "Contreras, Jorge, Evans, Barbara, Hurst, Samm, Patel, Bhavesh, Mcweeney, Shannon, Lee, Cecilia, & Lee, Aaron (2024).License terms for reusing the AI-READI dataset (1.0). Zenodo. https://doi.org/10.5281/zenodo.10642459",
     "type": "Reports"
   },
   {
@@ -108,7 +192,15 @@
     "url": "https://doi.org/10.5281/zenodo.7641684",
     "title": "AI-READI Steering Committee Charter",
     "subtitle": "",
-    "citation": "Lee, A., Owen, J., Patel, B., Nebeker, C., Lee, C., Zangwill, L., Hurst, S., & Singer, S. (2023). AI-READI Steering Committee Charter (1.0). Zenodo. https://doi.org/10.5281/ZENODO.7641684",
+    "citation": "Lee, Aaron, Owen, Julia, Patel, Bhavesh, Nebeker, Camille, Lee, Cecilia, Zangwill, Linda, Hurst, Samm, & Singer, Sara. (2023). AI-READI Steering Committee Charter (1.0). Zenodo. https://doi.org/10.5281/zenodo.7641684",
+    "type": "Reports"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://doi.org/10.5281/zenodo.7363102",
+    "title": "Software Development Best Practices of the AI-READI Project",
+    "subtitle": "",
+    "citation": "Patel, Bhavesh, Soundarajan, Sanjay, McWeeney, Shannon, Cordier, Benjamin A., & Benton, Erik S. (2022). Software Development Best Practices of the AI-READI Project (v1.0.0). Zenodo. https://doi.org/10.5281/zenodo.7363102",
     "type": "Reports"
   },
   {
@@ -120,27 +212,11 @@
     "type": "Web Articles"
   },
   {
-    "project": ["sodaforsparc"],
-    "url": "https://github.com/fairdataihub/SODA-for-SPARC",
-    "title": "SODA (Software to Organize Data Automatically) for SPARC",
-    "subtitle": "",
-    "citation": "Patel, B., Soundarajan, S., Marroquin, A., Clark, J., & Portillo, D. (2024). SODA (Software to Organize Data Automatically) for SPARC (Version 14.1.0). Zenodo. https://doi.org/10.5281/zenodo.8368612",
-    "type": "Software"
-  },
-  {
-    "project": ["fairshare"],
-    "url": "https://github.com/fairdataihub/FAIRshare",
-    "title": "FAIRshare",
-    "subtitle": "",
-    "citation": "Soundarajan, S., & Patel, B. (2023). FAIRshare: FAIR data and software sharing made easy (2.1.0). Zenodo. https://doi.org/10.5281/zenodo.8112716",
-    "type": "Software"
-  },
-  {
     "project": ["codefair"],
     "url": "https://github.com/fairdataihub/codefair-app",
     "title": "Codefair",
     "subtitle": "",
-    "citation": "Codefair. (2024). https://github.com/fairdataihub/codefair-app",
+    "citation": "Codefair. (started 2024). https://github.com/fairdataihub/codefair-app (Development status: Active)",
     "type": "Software"
   },
   {
@@ -148,7 +224,7 @@
     "url": "https://github.com/AI-READI/fairhub-app",
     "title": "FAIRhub Study Management Platform",
     "subtitle": "",
-    "citation": "FAIRhub. (2024). https://github.com/AI-READI/fairhub-app",
+    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-app (Development status: Active)",
     "type": "Software"
   },
   {
@@ -156,7 +232,7 @@
     "url": "https://github.com/AI-READI/fairhub-portal",
     "title": "FAIRhub Data Portal",
     "subtitle": "",
-    "citation": "FAIRhub. (2024). https://github.com/AI-READI/fairhub-portal",
+    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-portal (Development status: Active)",
     "type": "Software"
   },
   {
@@ -164,30 +240,31 @@
     "url": "https://github.com/AI-READI/pyfairdatatools",
     "title": "pyfairdatatools",
     "subtitle": "",
-    "citation": "pyfairdatatools. (2024). https://github.com/AI-READI/pyfairdatatools",
+    "citation": "pyfairdatatools. (started 2022). https://github.com/AI-READI/pyfairdatatools (Development status: Active)",
     "type": "Software"
   },
   {
-    "project": ["codefair"],
-    "url": "https://doi.org/10.7490/f1000research.1119824.1",
-    "title": "Codefair: Make biomedical research software FAIR without breaking a sweat",
-    "subtitle": "Slides presented at Bioinformatics Open Source Conference (BOSC), 2024",
-    "citation": "Portillo D, Soundarajan S, Clark J and Patel B. Codefair: Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:912",
-    "type": "Conference Presentations"
+    "project": ["aireadi"],
+    "url": "https://fairhub.io/datasets/1",
+    "title": "Flagship Dataset of Type 2 Diabetes from the AI-READI Project",
+    "subtitle": "",
+    "citation": "AI-READI Consortium. (2022). Flagship Dataset of Type 2 Diabetes from the AI-READI Project (1.0.0). FAIRhub. https://doi.org/10.60775/fairhub.1",
+    "type": "Datasets"
   },
   {
-    "project": ["codefair"],
-    "url": "https://doi.org/10.7490/f1000research.1119823.1",
-    "title": "Codefair - Make biomedical research software FAIR without breaking a sweat",
-    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
-    "citation": "Portillo D, Soundarajan S, Clark J and Patel B. Codefair - Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:911",
-    "type": "Posters"
+    "project": ["fairshare"],
+    "url": "https://github.com/fairdataihub/FAIRshare",
+    "title": "FAIRshare",
+    "subtitle": "",
+    "citation": "FAIRshare. (started 2021). https://github.com/fairdataihub/FAIRshare (Development status: Active)",
+    "type": "Software"
   },
   {
-    "title": "SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data",
-    "url": "https://doi.org/10.21105/joss.06140",
     "project": ["sodaforsparc"],
-    "citation": "Marroquin et al., (2024). SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data. Journal of Open Source Software, 9(100), 6140, https://doi.org/10.21105/joss.06140",
-    "type": "Journal Articles"
+    "url": "https://github.com/fairdataihub/SODA-for-SPARC",
+    "title": "SODA (Software to Organize Data Automatically) for SPARC",
+    "subtitle": "",
+    "citation": "SODA for SPARC. (started 2019). https://github.com/fairdataihub/SODA-for-SPARC (Development status: Active)",
+    "type": "Software"
   }
 ]

--- a/src/assets/data/publications.json
+++ b/src/assets/data/publications.json
@@ -1,5 +1,36 @@
 [
   {
+    "project": ["sodaforsparc"],
+    "title": "SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data",
+    "url": "https://doi.org/10.21105/joss.06140",
+    "citation": "Marroquin et al. (2024). SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data. Journal of Open Source Software, 9(100), 6140, https://doi.org/10.21105/joss.06140",
+    "type": "Journal Articles"
+  },
+  {
+    "project": ["fairshare", "fairbiors"],
+    "url": "https://doi.org/10.1038/s41597-023-02463-x",
+    "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
+    "subtitle": "",
+    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Scientific Data, 10(1). https://doi.org/10.1038/s41597-023-02463-x",
+    "type": "Journal Articles"
+  },
+  {
+    "project": ["sparclink"],
+    "url": "https://doi.org/10.12688/f1000research.75071.1",
+    "title": "SPARClink: an interactive tool to visualize the impact of the SPARC program",
+    "subtitle": "",
+    "citation": "Soundarajan, S., Kuruppu, S., Singh, A., Kim, J., & Achalla, M. (2022). SPARClink: an interactive tool to visualize the impact of the SPARC program. F1000Research, 11, 124. https://doi.org/10.12688/f1000research.75071.1",
+    "type": "Journal Articles"
+  },
+  {
+    "project": ["aqua"],
+    "url": "https://doi.org/10.12688/f1000research.73018.1",
+    "title": "AQUA: an Advanced QUery Architecture for the SPARC Portal",
+    "subtitle": "",
+    "citation": "Shahidi, N., Lin, X., Munarko, Y., Rasmy, L., & Ngo, T. (2021). AQUA: an Advanced QUery Architecture for the SPARC Portal. F1000Research, 10, 930. https://doi.org/10.12688/f1000research.73018.1",
+    "type": "Journal Articles"
+  },
+  {
     "project": ["aireadi"],
     "url": "https://doi.org/10.1101/2024.07.29.24310315",
     "title": "Perspective on Harnessing Large Language Models to Uncover Insights in Diabetes Wearable Data",
@@ -32,6 +63,62 @@
     "citation": "Quey, R., Schiefer, M. A., Kiran, A., & Patel, B. (2021). KnowMore: an automated knowledge discovery tool for the FAIR SPARC datasets. Cold Spring Harbor Laboratory. https://doi.org/10.1101/2021.08.08.455581",
     "type": "Preprints"
   },
+    {
+    "project": ["codefair"],
+    "url": "https://github.com/fairdataihub/codefair-app",
+    "title": "Codefair",
+    "subtitle": "",
+    "citation": "Codefair. (started 2024). https://github.com/fairdataihub/codefair-app (Development status: Active)",
+    "type": "Software"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://github.com/AI-READI/fairhub-app",
+    "title": "FAIRhub Study Management Platform",
+    "subtitle": "",
+    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-app (Development status: Active)",
+    "type": "Software"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://github.com/AI-READI/fairhub-portal",
+    "title": "FAIRhub Data Portal",
+    "subtitle": "",
+    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-portal (Development status: Active)",
+    "type": "Software"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://github.com/AI-READI/pyfairdatatools",
+    "title": "pyfairdatatools",
+    "subtitle": "",
+    "citation": "pyfairdatatools. (started 2022). https://github.com/AI-READI/pyfairdatatools (Development status: Active)",
+    "type": "Software"
+  },
+  {
+    "project": ["aireadi"],
+    "url": "https://fairhub.io/datasets/1",
+    "title": "Flagship Dataset of Type 2 Diabetes from the AI-READI Project",
+    "subtitle": "",
+    "citation": "AI-READI Consortium. (2022). Flagship Dataset of Type 2 Diabetes from the AI-READI Project (1.0.0). FAIRhub. https://doi.org/10.60775/fairhub.1",
+    "type": "Datasets"
+  },
+  {
+    "project": ["fairshare"],
+    "url": "https://github.com/fairdataihub/FAIRshare",
+    "title": "FAIRshare",
+    "subtitle": "",
+    "citation": "FAIRshare. (started 2021). https://github.com/fairdataihub/FAIRshare (Development status: Active)",
+    "type": "Software"
+  },
+  {
+    "project": ["sodaforsparc"],
+    "url": "https://github.com/fairdataihub/SODA-for-SPARC",
+    "title": "SODA (Software to Organize Data Automatically) for SPARC",
+    "subtitle": "",
+    "citation": "SODA for SPARC. (started 2019). https://github.com/fairdataihub/SODA-for-SPARC (Development status: Active)",
+    "type": "Software"
+  },
   {
     "project": ["sodaforsparc"],
     "url": "https://doi.org/10.1096/fasebj.2020.34.s1.02483",
@@ -41,35 +128,45 @@
     "type": "Abstract"
   },
   {
-    "project": ["sodaforsparc"],
-    "title": "SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data",
-    "url": "https://doi.org/10.21105/joss.06140",
-    "citation": "Marroquin et al., (2024). SODA: Software to Support the Curation and Sharing of FAIR Autonomic Nervous System Data. Journal of Open Source Software, 9(100), 6140, https://doi.org/10.21105/joss.06140",
-    "type": "Journal Articles"
+    "project": ["codefair"],
+    "url": "https://zenodo.org/records/13948381",
+    "title": "Codefair: Your Personal Assistant for Developing FAIR Software (Presentation)",
+    "subtitle": "",
+    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. (2024). Codefair: Your Personal Assistant for Developing FAIR Software (Presentation) (1.0.0). Zenodo. https://zenodo.org/records/13948381",
+    "type": "Conference Presentations"
   },
   {
-    "project": ["fairshare", "fairbiors"],
-    "url": "https://doi.org/10.1038/s41597-023-02463-x",
-    "title": "Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool",
+    "project": [],
+    "url": "https://zenodo.org/records/13159874",
+    "title": "Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024)",
     "subtitle": "",
-    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). Making Biomedical Research Software FAIR: Actionable Step-by-step Guidelines with a User-support Tool. Scientific Data, 10(1). https://doi.org/10.1038/s41597-023-02463-x",
-    "type": "Journal Articles"
+    "citation": "Patel, B. (2024). Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024) (1.0.0). Zenodo. https://zenodo.org/records/13159874",
+    "type": "Conference Presentations"
   },
   {
-    "project": ["sparclink"],
-    "url": "https://doi.org/10.12688/f1000research.75071.1",
-    "title": "SPARClink: an interactive tool to visualize the impact of the SPARC program",
-    "subtitle": "",
-    "citation": "Soundarajan, S., Kuruppu, S., Singh, A., Kim, J., & Achalla, M. (2022). SPARClink: an interactive tool to visualize the impact of the SPARC program. F1000Research, 11, 124. https://doi.org/10.12688/f1000research.75071.1",
-    "type": "Journal Articles"
+    "project": ["codefair"],
+    "url": "https://doi.org/10.7490/f1000research.1119824.1",
+    "title": "Codefair: Make biomedical research software FAIR without breaking a sweat",
+    "subtitle": "Slides presented at Bioinformatics Open Source Conference (BOSC), 2024",
+    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. Codefair: Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:912",
+    "type": "Conference Presentations"
+  },
+
+  {
+    "project": ["fairbiors"],
+    "url": "https://doi.org/10.7490/f1000research.1119609.1",
+    "title": "FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR",
+    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
+    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR. F1000 Research Limited. https://doi.org/10.7490/f1000research.1119609.1",
+    "type": "Conference Presentations"
   },
   {
-    "project": ["aqua"],
-    "url": "https://doi.org/10.12688/f1000research.73018.1",
-    "title": "AQUA: an Advanced QUery Architecture for the SPARC Portal",
-    "subtitle": "",
-    "citation": "Shahidi, N., Lin, X., Munarko, Y., Rasmy, L., & Ngo, T. (2021). AQUA: an Advanced QUery Architecture for the SPARC Portal. F1000Research, 10, 930. https://doi.org/10.12688/f1000research.73018.1",
-    "type": "Journal Articles"
+    "project": ["fairshare"],
+    "url": "https://doi.org/10.7490/f1000research.1119055.1",
+    "title": "Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare",
+    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
+    "citation": "Patel, B., & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
+    "type": "Conference Presentations"
   },
   {
     "project": ["aireadi"],
@@ -128,48 +225,6 @@
     "type": "Webinars/Lectures"
   },
   {
-    "project": ["codefair"],
-    "url": "https://zenodo.org/records/13948381",
-    "title": "Codefair: Your Personal Assistant for Developing FAIR Software (Presentation)",
-    "subtitle": "",
-    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. (2024). Codefair: Your Personal Assistant for Developing FAIR Software (Presentation) (1.0.0). Zenodo. https://zenodo.org/records/13948381",
-    "type": "Conference Presentations"
-  },
-  {
-    "project": [],
-    "url": "https://zenodo.org/records/13159874",
-    "title": "Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024)",
-    "subtitle": "",
-    "citation": "Patel, B. (2024). Presentation - Making FAIR Fair to the Researchers (Force11 Conference - Force2024) (1.0.0). Zenodo. https://zenodo.org/records/13159874",
-    "type": "Conference Presentations"
-  },
-  {
-    "project": ["codefair"],
-    "url": "https://doi.org/10.7490/f1000research.1119824.1",
-    "title": "Codefair: Make biomedical research software FAIR without breaking a sweat",
-    "subtitle": "Slides presented at Bioinformatics Open Source Conference (BOSC), 2024",
-    "citation": "Portillo, D., Soundarajan, S., Clark, J., & Patel, B. Codefair: Make biomedical research software FAIR without breaking a sweat. F1000Research 2024, 13:912",
-    "type": "Conference Presentations"
-  },
-
-  {
-    "project": ["fairbiors"],
-    "url": "https://doi.org/10.7490/f1000research.1119609.1",
-    "title": "FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR",
-    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2023 and Bioinformatics Open Source Conference (BOSC) 2023",
-    "citation": "Patel, B., Soundarajan, S., Ménager, H., & Hu, Z. (2023). FAIR-BioRS: Actionable guidelines for making biomedical research software FAIR. F1000 Research Limited. https://doi.org/10.7490/f1000research.1119609.1",
-    "type": "Conference Presentations"
-  },
-  {
-    "project": ["fairshare"],
-    "url": "https://doi.org/10.7490/f1000research.1119055.1",
-    "title": "Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare",
-    "subtitle": "Slides presented at Intelligent Systems for Molecular Biology (ISMB) 2022 and Bioinformatics Open Source Conference (BOSC) 2022",
-    "citation": "Patel, B., & Soundarajan, S. (2022). Making biomedical research software findable, accessible, interoperable, reusable (FAIR) with FAIRshare. F1000 Research Limited. https://doi.org/10.7490/F1000RESEARCH.1119055.1",
-    "type": "Conference Presentations"
-  },
-
-  {
     "project": ["aireadi"],
     "url": "https://zenodo.org/records/13328255",
     "title": "AI-READI Code of Conduct",
@@ -208,61 +263,5 @@
     "subtitle": "",
     "citation": "SPARC Data Structure: Rationale and Design of a FAIR Standard for Biomedical Research Data. (2021). SPARC. https://sparc.science/news-and-events/community-spotlight/success-stories/sharing-is-caring-making-sparc-data-fair-with-soda",
     "type": "Web Articles"
-  },
-  {
-    "project": ["codefair"],
-    "url": "https://github.com/fairdataihub/codefair-app",
-    "title": "Codefair",
-    "subtitle": "",
-    "citation": "Codefair. (started 2024). https://github.com/fairdataihub/codefair-app (Development status: Active)",
-    "type": "Software"
-  },
-  {
-    "project": ["aireadi"],
-    "url": "https://github.com/AI-READI/fairhub-app",
-    "title": "FAIRhub Study Management Platform",
-    "subtitle": "",
-    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-app (Development status: Active)",
-    "type": "Software"
-  },
-  {
-    "project": ["aireadi"],
-    "url": "https://github.com/AI-READI/fairhub-portal",
-    "title": "FAIRhub Data Portal",
-    "subtitle": "",
-    "citation": "FAIRhub. (started 2022). https://github.com/AI-READI/fairhub-portal (Development status: Active)",
-    "type": "Software"
-  },
-  {
-    "project": ["aireadi"],
-    "url": "https://github.com/AI-READI/pyfairdatatools",
-    "title": "pyfairdatatools",
-    "subtitle": "",
-    "citation": "pyfairdatatools. (started 2022). https://github.com/AI-READI/pyfairdatatools (Development status: Active)",
-    "type": "Software"
-  },
-  {
-    "project": ["aireadi"],
-    "url": "https://fairhub.io/datasets/1",
-    "title": "Flagship Dataset of Type 2 Diabetes from the AI-READI Project",
-    "subtitle": "",
-    "citation": "AI-READI Consortium. (2022). Flagship Dataset of Type 2 Diabetes from the AI-READI Project (1.0.0). FAIRhub. https://doi.org/10.60775/fairhub.1",
-    "type": "Datasets"
-  },
-  {
-    "project": ["fairshare"],
-    "url": "https://github.com/fairdataihub/FAIRshare",
-    "title": "FAIRshare",
-    "subtitle": "",
-    "citation": "FAIRshare. (started 2021). https://github.com/fairdataihub/FAIRshare (Development status: Active)",
-    "type": "Software"
-  },
-  {
-    "project": ["sodaforsparc"],
-    "url": "https://github.com/fairdataihub/SODA-for-SPARC",
-    "title": "SODA (Software to Organize Data Automatically) for SPARC",
-    "subtitle": "",
-    "citation": "SODA for SPARC. (started 2019). https://github.com/fairdataihub/SODA-for-SPARC (Development status: Active)",
-    "type": "Software"
   }
 ]

--- a/src/pages/impact.tsx
+++ b/src/pages/impact.tsx
@@ -96,6 +96,7 @@ export async function getStaticProps() {
     `Journal Articles`,
     `Preprints`,
     `Software`,
+    `Datasets`,
     `Conference Presentations`,
     `Posters`,
     `Webinars/Lectures`,

--- a/src/pages/impact.tsx
+++ b/src/pages/impact.tsx
@@ -93,13 +93,14 @@ export async function getStaticProps() {
   }
 
   const sortingOrder = [
-    `Journal Article`,
-    `Preprint`,
+    `Journal Articles`,
+    `Preprints`,
     `Software`,
-    `Poster`,
-    `Report`,
-    `Conference Presentation`,
-    `Web Article`,
+    `Conference Presentations`,
+    `Posters`,
+    `Webinars/Lectures`,
+    `Reports`,
+    `Web Articles`,
   ];
 
   const sortedGrouped = [];


### PR DESCRIPTION
- Sorting order of publication types in descending format on the Impact page to ensure consistent categorization.
- Added Webinars/Lectures header
- Rename all headers as plural
- Modify all citation formats for consistency
- Modify software section format according to software release date
