### PR TITLE
feat: ✨ usrse25  event

### DIFF
--- a/events/sabpa-2025.md
+++ b/events/sabpa-2025.md
@@ -1,5 +1,5 @@
 ---
-title: 'Talk: Making Data AI-Ready at SABPA OC/LA AI for Biotechnology Seminar Series'
+title: 'SABPA OC/LA AI for Biotechnology Seminar Series'
 startDateTime: '2025-08-02T13:30:00'
 endDateTime: '2025-08-02T19:00:00'
 heroImage: 'https://images.unsplash.com/photo-1675627453057-c56dc0502ffd?q=80&w=2532&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
@@ -33,4 +33,4 @@ The event starts at 1:30 PT. Our talk is part of the keynote presentations and s
 
 ## 🔗 Link to Materials
 
-Presetation slides and all related resources are available in this [GitHub repository](https://github.com/fairdataihub/ai-ready-SABPA-2025).
+Slides of the presentation and all related resources are available in this [GitHub repository](https://github.com/fairdataihub/ai-ready-SABPA-2025).

--- a/events/usrse25.md
+++ b/events/usrse25.md
@@ -1,0 +1,36 @@
+---
+title: 'USRSE 2025'
+startDateTime: '2025-10-06T11:00:00'
+endDateTime: '2025-10-08T18:30:00'
+heroImage: 'https://images.unsplash.com/photo-1594729095022-e2f6d2eece9c?q=80&w=1742&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
+subtitle: 'The third annual conference from the United States Research Software Engineer Association (US-RSE).'
+type: 'Conference'
+timeZone: 'America/Los_Angeles'
+location: 'Philadelphia, CA'
+---
+
+## 📝 Event Description
+
+**USRSE’25** is the third annual conference of the **United States Research Software Engineer Association (US-RSE)**, gathering research software engineers, developers, scientists, and team leaders to explore the evolving role of software in research. This year’s theme, **“Code, Practices, and People”**, emphasizes the tools, methodologies, and community efforts that support effective and sustainable research software development. The conference will feature sessions on secure and reproducible coding, open-source infrastructure, workforce development, leadership, and collaborations that advance both science and software.
+
+The program of the conference will be available [here](https://us-rse.org/usrse25/program/).
+
+## 💡 Our Role / Contribution
+
+Bhavesh Patel will deliver two presentations at USRSE’25 focused on advancing the FAIRness of research software. The first talk will introduce the work of the **Actionable Guidelines for FAIR Research Software (Actionable FAIR4RS) Task Force**, formed under the **Research Software Alliance (ReSA)**. The task force is translating the FAIR4RS Principles into practical guidelines to make any research software FAIR. The second talk will highlight the latest developments in **Codefair**, an open-source platform that automates FAIR compliance for research software through GitHub and a user-friendly web app.
+
+## 📍 Location
+
+Philadelphia, Pennsylvania  
+[Conference Website](https://us-rse.org/usrse25)
+
+## 🗓 Date and Time
+
+October 6–8, 2025
+(Exact date and time of talks TBD – see the [conference program](https://us-rse.org/usrse25/program/))
+
+## 🔗 Link to Materials
+
+Material of the Actionable FAIR4RS Task Force presentation: coming soon.
+
+Material of the Codefair presentation: coming soon.


### PR DESCRIPTION
## Summary by Sourcery

Add USRSE 2025 event details and improve SABPA-2025 event metadata and resource description

New Features:
- Add a new event page for USRSE 2025 with full metadata, description, contribution details, and resource links

Enhancements:
- Update the SABPA-2025 event title for clarity
- Refine wording of the slide resources link in the SABPA-2025 event