### PR TITLE
fix: 🐛 events time

### DIFF
--- a/events/RDA-VP24-2025.md
+++ b/events/RDA-VP24-2025.md
@@ -1,7 +1,7 @@
 ---
 title: '24th Research Data Alliance (RDA) Plenary Meeting (RDA VP24)'
-startDateTime: '2025-04-07T00:00:00'
-endDateTime: '2025-04-10T19:00:00'
+startDateTime: '2025-04-07'
+endDateTime: '2025-04-11'
 heroImage: 'https://images.unsplash.com/photo-1523961131990-5ea7c61b2107?q=80&w=1548&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
 subtitle: 'The 24th RDA Plenary will spotlight the vital role of data across rapidly changing technological landscapes.'
 type: 'Conference'

--- a/events/aimahead-2025.md
+++ b/events/aimahead-2025.md
@@ -1,7 +1,7 @@
 ---
 title: '2025 AIM-AHEAD Annual Meeting'
-startDateTime: '2025-07-07T20:00:00'
-endDateTime: '2025-07-09T22:00:00'
+startDateTime: '2025-07-07'
+endDateTime: '2025-07-09'
 heroImage: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?q=80&w=2232&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
 subtitle: 'Annual meeting of the NIH AIM-AHEAD Program'
 type: 'Conference'

--- a/events/arvo-2025.md
+++ b/events/arvo-2025.md
@@ -1,5 +1,5 @@
 ---
-title: 'ARVO 2025'
+title: 'ARVO 2025 course Artificial Intelligence for Ophthalmic Research'
 startDateTime: '2025-05-03T05:00:00'
 endDateTime: '2025-05-03T14:00:00'
 heroImage: 'https://i.imgur.com/nY0iCPK.png'

--- a/events/hpc-webinar-may-2025.md
+++ b/events/hpc-webinar-may-2025.md
@@ -1,7 +1,7 @@
 ---
 title: 'HPC Best Practices Webinar Series May 2025'
-startDateTime: '2025-05-07T16:00:00'
-endDateTime: '2025-05-07T17:00:00'
+startDateTime: '2025-05-07T10:00:00'
+endDateTime: '2025-05-07T11:00:00'
 heroImage: 'https://images.unsplash.com/photo-1526925539332-aa3b66e35444?q=80&w=930&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
 subtitle: 'Applying FAIR principles to research software with practical guidelines and tools.'
 type: 'Webinar'

--- a/events/usrse25.md
+++ b/events/usrse25.md
@@ -1,7 +1,7 @@
 ---
 title: 'USRSE 2025'
-startDateTime: '2025-10-06T11:00:00'
-endDateTime: '2025-10-08T18:30:00'
+startDateTime: '2025-10-06'
+endDateTime: '2025-10-08'
 heroImage: 'https://images.unsplash.com/photo-1594729095022-e2f6d2eece9c?q=80&w=1742&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
 subtitle: 'The third annual conference from the United States Research Software Engineer Association (US-RSE).'
 type: 'Conference'


### PR DESCRIPTION
## Summary by Sourcery

Normalize and correct event date and time metadata across several event entries.

Enhancements:
- Standardize multi-day event entries to use date-only start and end fields and extend RDA VP24 end date by one day
- Rename HPC webinar file and adjust its session time from 16:00–17:00 to 10:00–11:00
- Update ARVO event title to specify the "Artificial Intelligence for Ophthalmic Research" course