### PR TITLE
fix: 🐛 Update focusing between Dialog and Popover component

### DIFF
--- a/src/components/careers/dateRangePicker.tsx
+++ b/src/components/careers/dateRangePicker.tsx
@@ -38,7 +38,7 @@ export function DatePickerWithRange({
   };
 
   return (
-    <div className={cn(`grid gap-2`, className)}>
+    <div className={cn(`z-50 grid gap-2`, className)}>
       <Popover>
         <PopoverTrigger asChild>
           <Button

--- a/src/components/careers/internshipForm.jsx
+++ b/src/components/careers/internshipForm.jsx
@@ -65,7 +65,7 @@ const IntershipForm = () => {
   };
   return (
     <>
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={setOpen} modal={false}>
         <DialogTrigger className="cursor-pointer rounded border-none bg-black px-6 py-2 text-lg text-white ring-2 ring-transparent ring-offset-2 transition-all hover:ring-pink-600 focus:outline-none">
           Apply
         </DialogTrigger>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        `bg-popover text-popover-foreground z-50 w-72 rounded-md border p-4 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2`,
+        `bg-popover text-popover-foreground z-[999] w-72 rounded-md border p-4 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2`,
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary by Sourcery

Adjust stacking context and interactivity between Dialog and Popover components to ensure popovers render above dialogs and remain focusable when the dialog is open

Bug Fixes:
- Prevent the Popover from being hidden behind the Dialog by raising its z-index
- Allow interaction with the Popover when the Dialog is open by disabling the Dialog’s modal behavior

Enhancements:
- Add a z-index utility class to the date range picker wrapper to ensure it displays above other elements