### PR TITLE
Fix GitHub link and enhance section formatting

### DIFF
--- a/blog/rag-setup.md
+++ b/blog/rag-setup.md
@@ -56,13 +56,13 @@ The retrieved content is provided to a large language model such as [Gemini](htt
 
 ## 🚀 Build a RAG System (Step-by-Step)
 
-👉 [View on GitHub](https://github.com/fairdataihub/RAG_blog/tree/main)
+👉 [View on GitHub](https://github.com/fairdataihub/LLM-RAG-demo)
 
 ### 🧭 Use Case:
 In this scenario, we collect about 20 pages from the **FAIR Data Innovations Hub** website (`fairdataihub.org`) and save them locally as plain text files. We then ask the same questions using two approaches: **No-RAG**, where a local Llama model answers from general knowledge, and **RAG**, where the system first retrieves the most relevant website text chunks using **Ollama embeddings + FAISS** and then generates an answer based only on that retrieved context. Comparing the outputs side by side highlights how RAG produces answers that are more **website-grounded** and less likely to hallucinate—especially for site-specific details like leadership/team information, project names, and tool descriptions (e.g., Posters.science and DMP Chef).
 
 ---
-## 🔧 1) Install Python dependencies (run once)
+## 🔧 1 — Install Python dependencies (run once)
 
 First, install all required packages from `requirements.txt`.  
 This ensures your environment has everything needed for web crawling, text processing, vector indexing (FAISS), and Ollama + LangChain integration.

--- a/blog/rag-setup.md
+++ b/blog/rag-setup.md
@@ -62,7 +62,7 @@ The retrieved content is provided to a large language model such as [Gemini](htt
 In this scenario, we collect about 20 pages from the **FAIR Data Innovations Hub** website (`fairdataihub.org`) and save them locally as plain text files. We then ask the same questions using two approaches: **No-RAG**, where a local Llama model answers from general knowledge, and **RAG**, where the system first retrieves the most relevant website text chunks using **Ollama embeddings + FAISS** and then generates an answer based only on that retrieved context. Comparing the outputs side by side highlights how RAG produces answers that are more **website-grounded** and less likely to hallucinate—especially for site-specific details like leadership/team information, project names, and tool descriptions (e.g., Posters.science and DMP Chef).
 
 ---
-## 🔧 1 — Install Python dependencies (run once)
+## 🔧 Step 1 — Install Python dependencies (run once)
 
 First, install all required packages from `requirements.txt`.  
 This ensures your environment has everything needed for web crawling, text processing, vector indexing (FAISS), and Ollama + LangChain integration.


### PR DESCRIPTION
Updated GitHub link and improved section titles for clarity.

## Summary by Sourcery

Update blog post link to the correct GitHub repository and improve a step title for clearer section formatting.

Documentation:
- Correct the GitHub repository link in the RAG setup blog post.
- Refine the first setup step heading to use clearer numbering and wording.