### PR TITLE
feat(posters-science): update GitHub repo link to poster2json and add…

### DIFF
--- a/src/pages/posters-science.tsx
+++ b/src/pages/posters-science.tsx
@@ -69,12 +69,12 @@ const PostersScience: React.FC<PublicationsItemList> = ({ publications }) => {
         title="Development approach"
         description={`Posters.science is developed using an open-source approach, enabling transparency, reuse, and collaboration with the broader community of researchers, institutions, and tool builders.`}
         sideImageSrc="/images/github-logo.svg"
-        sideImageUrl="https://github.com/fairdataihub/posters-science"
+        sideImageUrl="https://github.com/fairdataihub/poster2json"
         sideImageAlt="GitHub logo"
         additionalLinks={[
           {
             text: `Explore the GitHub repository`,
-            href: `https://github.com/fairdataihub/posters-science`,
+            href: `https://github.com/fairdataihub/poster2json`,
             target: `_blank`,
           },
         ]}
@@ -143,6 +143,12 @@ const PostersScience: React.FC<PublicationsItemList> = ({ publications }) => {
             href: `/team/#Aydan-Gasimova`,
             external: false,
             image: `/images/people/aydan-head.jpg`,
+          },
+          {
+            name: `James ONeill`,
+            href: `/team/#James-ONeill`,
+            external: false,
+            image: `/images/people/james-head.jpg`,
           },
         ]}
       />


### PR DESCRIPTION
Add James ONeill to posters.science team and update gh repo.
@slugb0t

## Summary by Sourcery

Update posters.science page metadata to point to the new GitHub repository and reflect team membership changes.

New Features:
- Add James ONeill to the posters.science team listing on the posters-science page.

Enhancements:
- Update GitHub repository links on the posters-science page to reference the poster2json repository instead of the previous posters-science repository.