### PR TITLE
Updates

### DIFF
--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -232,6 +232,7 @@ jobs:
     permissions:
       contents: read
       deployments: read
+      actions: read
       issues: write
       pull-requests: write
 
@@ -257,6 +258,7 @@ jobs:
           script: |
             const previewUrl = `https://${process.env.KAMAL_APP_DOMAIN}`;
             const issue_number = context.payload.pull_request.number;
+            const branch = context.payload.pull_request.head.ref;
 
             // Look up the latest deployment for this preview environment
             const { data: deployments } = await github.rest.repos.listDeployments({
@@ -284,7 +286,22 @@ jobs:
                 body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
               }
             } else {
-              body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
+              // No deployment record yet — check if deploy-ui is currently running for this branch.
+              // The GitHub deployment record is only created after kamal completes, so a concurrent
+              // push can leave listDeployments empty while the workflow is still in progress.
+              const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch,
+                status: 'in_progress',
+                per_page: 10,
+              });
+              const deployRunning = runs.workflow_runs.some(r => r.name === 'Deploy preview environment');
+              if (deployRunning) {
+                body = `## Preview deployment in progress\n\nA preview environment is being built and will be available at [${previewUrl}](${previewUrl}) once ready. Please wait...`;
+              } else {
+                body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
+              }
             }
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -10,7 +10,7 @@ on:
       - main
       - next
   pull_request:
-    types: [closed]
+    types: [opened, reopened, closed]
   delete:
 
 jobs:
@@ -220,6 +220,96 @@ jobs:
                 repo: context.repo.repo,
                 issue_number,
                 body
+              });
+            }
+
+  notify-pr-on-open:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      !contains(fromJson('["main","next"]'), github.event.pull_request.head.ref)
+    permissions:
+      contents: read
+      deployments: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Set preview app name and domain
+        run: |
+          BRANCH_SLUG=$(echo "${{ github.event.pull_request.head.ref }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9-]/-/g' \
+            | sed 's/-\+/-/g' \
+            | sed 's/^-//;s/-$//')
+
+          APP_NAME="fairdataihub-website-${BRANCH_SLUG}"
+          APP_DOMAIN="website-${BRANCH_SLUG}.fairdataihub.org"
+
+          echo "KAMAL_APP_NAME=${APP_NAME}" >> "$GITHUB_ENV"
+          echo "KAMAL_APP_DOMAIN=${APP_DOMAIN}" >> "$GITHUB_ENV"
+
+      - name: Post preview status comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const previewUrl = `https://${process.env.KAMAL_APP_DOMAIN}`;
+            const issue_number = context.payload.pull_request.number;
+
+            // Look up the latest deployment for this preview environment
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: process.env.KAMAL_APP_NAME,
+              per_page: 1,
+            });
+
+            let body;
+            if (deployments.length > 0) {
+              const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployments[0].id,
+                per_page: 1,
+              });
+              const state = statuses[0]?.state;
+              if (state === 'success') {
+                const updatedAt = new Date(deployments[0].updated_at).toUTCString();
+                body = `## Preview deployment ready\n\n**Preview URL:** [${previewUrl}](${previewUrl})\n\n> Last deployed: ${updatedAt}`;
+              } else if (state === 'in_progress') {
+                body = `## Preview deployment in progress\n\nA preview environment is being built and will be available at [${previewUrl}](${previewUrl}) once ready. Please wait...`;
+              } else {
+                body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
+              }
+            } else {
+              body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            const existing = comments.find(
+              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
               });
             }
 

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -76,7 +76,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             let commentId;
@@ -204,7 +204,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             if (existing) {
@@ -311,7 +311,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             if (existing) {
@@ -461,7 +461,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             if (existing) {

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -394,7 +394,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const { data: deployments } = await github.rest.repos.listDeployments({
               owner: context.repo.owner,
@@ -410,6 +410,11 @@ jobs:
                 deployment_id: deployment.id,
                 state: 'inactive',
                 description: 'Preview environment removed'
+              });
+              await github.rest.repos.deleteDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id
               });
             }
 


### PR DESCRIPTION
## Summary by Sourcery

Extend preview deployment workflow to notify pull requests about preview environment status on open and ensure deployments are fully cleaned up on removal.

CI:
- Trigger the deploy-preview-app workflow on pull request open and reopen events in addition to close.
- Add a job that comments or updates a status message on pull requests with the current preview deployment state and URL.
- Use a personal access token when managing preview deployments and delete deployment records after marking environments inactive.