### PR TITLE
feat: ✨ Additional features to Vercel transition

### DIFF
--- a/.github/workflows/cleanup-preview-envs.yml
+++ b/.github/workflows/cleanup-preview-envs.yml
@@ -1,0 +1,187 @@
+name: Cleanup stale preview environments
+
+on:
+  schedule:
+    - cron: '0 2 * * 1' # Every Monday at 2am UTC
+  workflow_dispatch:
+
+jobs:
+  find-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    outputs:
+      stale_envs: ${{ steps.find.outputs.stale_envs }}
+
+    steps:
+      - name: Find stale preview environments
+        id: find
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const STALE_DAYS = 90;
+            const STALE_MS = STALE_DAYS * 24 * 60 * 60 * 1000;
+            const ENV_PREFIX = 'fairdataihub-website-';
+            const now = Date.now();
+
+            function slugify(branch) {
+              return branch
+                .toLowerCase()
+                .replace(/[^a-z0-9-]/g, '-')
+                .replace(/-+/g, '-')
+                .replace(/^-|-$/g, '');
+            }
+
+            // List all branches
+            const branches = await github.paginate(github.rest.repos.listBranches, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            // Build map: expected environment name → branch object
+            const branchByEnv = new Map();
+            for (const branch of branches) {
+              const envName = `${ENV_PREFIX}${slugify(branch.name)}`;
+              branchByEnv.set(envName, branch);
+            }
+
+            // Get all GitHub environments
+            const { data: envData } = await github.rest.repos.getAllEnvironments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const previewEnvs = (envData.environments || []).filter(e =>
+              e.name.startsWith(ENV_PREFIX)
+            );
+
+            const staleEnvs = [];
+
+            for (const env of previewEnvs) {
+              const branch = branchByEnv.get(env.name);
+
+              if (!branch) {
+                core.info(`${env.name}: branch no longer exists → stale`);
+                staleEnvs.push(env.name);
+                continue;
+              }
+
+              // Check last commit date on the branch
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: branch.commit.sha,
+              });
+
+              const lastPush = new Date(commit.commit.committer.date).getTime();
+              const ageDays = Math.floor((now - lastPush) / (24 * 60 * 60 * 1000));
+
+              if (now - lastPush > STALE_MS) {
+                core.info(`${env.name}: last push ${ageDays} days ago → stale`);
+                staleEnvs.push(env.name);
+              } else {
+                core.info(`${env.name}: last push ${ageDays} days ago → active`);
+              }
+            }
+
+            core.setOutput('stale_envs', JSON.stringify(staleEnvs));
+            core.info(`Found ${staleEnvs.length} stale environment(s)`);
+
+  cleanup:
+    needs: find-stale
+    runs-on: ubuntu-latest
+    if: needs.find-stale.outputs.stale_envs != '[]'
+    permissions:
+      contents: read
+      deployments: write
+
+    env:
+      KAMAL_REGISTRY_LOGIN_SERVER: ${{ secrets.KAMAL_REGISTRY_LOGIN_SERVER }}
+      KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}
+      KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
+      KAMAL_SERVER_IP: ${{ secrets.KAMAL_SERVER_IP }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3.1
+          bundler-cache: true
+
+      - run: gem install kamal
+
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Remove stale Kamal preview deployments
+        run: |
+          echo '${{ needs.find-stale.outputs.stale_envs }}' | jq -r '.[]' | while read -r env_name; do
+            branch_slug="${env_name#fairdataihub-website-}"
+            export KAMAL_APP_NAME="$env_name"
+            export KAMAL_APP_DOMAIN="website-${branch_slug}.fairdataihub.org"
+            echo "Removing stale preview: $env_name"
+            kamal remove -y -d preview || echo "Warning: kamal remove failed for $env_name, continuing..."
+          done
+
+      - name: Set up crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Delete stale registry images
+        run: |
+          crane auth login "$KAMAL_REGISTRY_LOGIN_SERVER" \
+            -u "$KAMAL_REGISTRY_USERNAME" \
+            -p "$KAMAL_REGISTRY_PASSWORD"
+
+          echo '${{ needs.find-stale.outputs.stale_envs }}' | jq -r '.[]' | while read -r env_name; do
+            echo "Deleting registry image: $env_name"
+            crane ls "$KAMAL_REGISTRY_LOGIN_SERVER/$env_name" 2>/dev/null \
+              | xargs -I{} crane delete "$KAMAL_REGISTRY_LOGIN_SERVER/$env_name:{}" 2>/dev/null \
+              || true
+          done
+
+      - name: Deactivate and delete GitHub environments
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const staleEnvs = JSON.parse('${{ needs.find-stale.outputs.stale_envs }}');
+
+            for (const envName of staleEnvs) {
+              try {
+                const { data: deployments } = await github.rest.repos.listDeployments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  environment: envName,
+                  per_page: 100,
+                });
+
+                for (const d of deployments) {
+                  await github.rest.repos.createDeploymentStatus({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    deployment_id: d.id,
+                    state: 'inactive',
+                  });
+                  await github.rest.repos.deleteDeployment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    deployment_id: d.id,
+                  });
+                }
+
+                await github.rest.repos.deleteAnEnvironment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  environment_name: envName,
+                });
+
+                core.info(`Cleaned up: ${envName}`);
+              } catch (e) {
+                core.warning(`Failed to clean up ${envName}: ${e.message}`);
+              }
+            }

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -18,6 +18,9 @@ jobs:
   # Job for deploying the UI/frontend application
   deploy-ui:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
 
     # Environment variables for Kamal deployment and container registry
     env:
@@ -33,34 +36,85 @@ jobs:
       # Step 1: Checkout the repository code
       - uses: actions/checkout@v4
 
-      # Step 2: Setup Ruby environment for Kamal deployment tool
+      # Step 2: Create GitHub deployment record and mark as in_progress
+      - name: Create GitHub deployment
+        id: create-deployment
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref,
+              environment: 'production',
+              auto_merge: false,
+              required_contexts: [],
+            });
+
+            core.setOutput('deployment_id', deployment.data.id);
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'in_progress',
+              description: 'Deployment in progress',
+            });
+
+      # Step 3: Setup Ruby environment for Kamal deployment tool
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.1
           bundler-cache: true # Cache Ruby dependencies for faster builds
 
-      # Step 3: Install Kamal deployment tool
+      # Step 4: Install Kamal deployment tool
       - run: gem install kamal
 
-      # Step 4: Setup SSH agent for server access
+      # Step 5: Setup SSH agent for server access
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      # Step 5: Setup Docker Buildx for better caching and performance
+      # Step 6: Setup Docker Buildx for better caching and performance
       - name: Set up Docker Buildx for cache
         uses: docker/setup-buildx-action@v3
 
-      # Step 6: Verify Kamal installation
+      # Step 7: Verify Kamal installation
       - run: kamal version
 
-      # Step 7: Release any existing deployment locks
+      # Step 8: Release any existing deployment locks
       # This prevents conflicts when redeploying while a previous deployment is running
       - run: kamal lock release
       # Uncomment for verbose output during troubleshooting:
       # - run: kamal lock release --verbose
 
-      # Step 8: Initial Kamal setup (only needed once per server)
+      # Step 9: Initial Kamal setup (only needed once per server)
       # Note: This step might need to be run manually on the server first time
       # to add the user to the docker group: `sudo usermod -aG docker $USER | newgrp docker | docker ps`
-      - run: kamal setup
+      - id: kamal-deploy
+        run: kamal setup
+
+      # Step 10: Update GitHub deployment status based on outcome
+      - name: Update GitHub deployment status
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const deploymentId = '${{ steps.create-deployment.outputs.deployment_id }}';
+            if (!deploymentId) return;
+
+            const deploySucceeded = '${{ steps.kamal-deploy.outcome }}' === 'success';
+            const statusPayload = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: parseInt(deploymentId),
+              state: deploySucceeded ? 'success' : 'failure',
+              description: deploySucceeded ? 'Deployment succeeded' : 'Deployment failed',
+            };
+            if (deploySucceeded) {
+              statusPayload.environment_url = `https://${process.env.KAMAL_APP_DOMAIN}`;
+            }
+            await github.rest.repos.createDeploymentStatus(statusPayload);

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -11,8 +11,6 @@ on:
       - next
   pull_request:
     types: [closed]
-  pull_request_target:
-    types: [opened, reopened, synchronize]
   delete:
 
 jobs:
@@ -50,6 +48,58 @@ jobs:
           echo "KAMAL_APP_NAME=${APP_NAME}" >> "$GITHUB_ENV"
           echo "KAMAL_APP_DOMAIN=${APP_DOMAIN}" >> "$GITHUB_ENV"
 
+      - name: Post in-progress comment on PR
+        id: post-comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const branch = '${{ github.ref_name }}';
+            const previewUrl = `https://${process.env.KAMAL_APP_DOMAIN}`;
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:${branch}`
+            });
+
+            if (prs.length === 0) return;
+
+            const issue_number = prs[0].number;
+            const body = `## Preview deployment in progress\n\nA preview environment is being built and will be available at [${previewUrl}](${previewUrl}) once ready. Please wait...`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number
+            });
+
+            const existing = comments.find(
+              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+            );
+
+            let commentId;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+              commentId = existing.id;
+            } else {
+              const { data: newComment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body
+              });
+              commentId = newComment.id;
+            }
+
+            core.setOutput('comment_id', commentId);
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3.1
@@ -61,40 +111,82 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
-      - run: kamal deploy -d preview
+      - id: kamal-deploy
+        run: kamal deploy -d preview
 
-      - name: Create GitHub deployment
+      - name: Manage GitHub deployment
+        if: always()
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const deploySucceeded = '${{ steps.kamal-deploy.outcome }}' === 'success';
+
             const deployment = await github.rest.repos.createDeployment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: context.ref,
-              environment: '${{ env.KAMAL_APP_NAME }}',
+              environment: process.env.KAMAL_APP_NAME,
               auto_merge: false,
               required_contexts: []
             });
 
-            await github.rest.repos.createDeploymentStatus({
+            const statusPayload = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               deployment_id: deployment.data.id,
-              state: 'success',
-              environment_url: 'https://${{ env.KAMAL_APP_DOMAIN }}',
-              description: 'Preview deployment ready'
+              state: deploySucceeded ? 'success' : 'failure',
+              description: deploySucceeded ? 'Preview deployment ready' : 'Preview deployment failed'
+            };
+            if (deploySucceeded) {
+              statusPayload.environment_url = `https://${process.env.KAMAL_APP_DOMAIN}`;
+            }
+            await github.rest.repos.createDeploymentStatus(statusPayload);
+
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: process.env.KAMAL_APP_NAME,
+              per_page: 100
             });
 
-      - name: Comment preview URL on PR
+            for (const d of deployments) {
+              if (d.id === deployment.data.id) continue;
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id,
+                state: 'inactive'
+              });
+            }
+
+      - name: Update PR comment
+        if: always()
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           script: |
-            const branch = '${{ github.ref_name }}';
-            const previewUrl = 'https://${{ env.KAMAL_APP_DOMAIN }}';
-            const body = `## Preview deployment ready\n\n**Preview URL:** [${previewUrl}](${previewUrl})`;
+            const previewUrl = `https://${process.env.KAMAL_APP_DOMAIN}`;
+            const deploySucceeded = '${{ steps.kamal-deploy.outcome }}' === 'success';
 
+            const body = deploySucceeded
+              ? `## Preview deployment ready\n\n**Preview URL:** [${previewUrl}](${previewUrl})\n\n> Last deployed: ${new Date().toUTCString()}`
+              : `## Preview deployment failed\n\nThe deployment for this branch failed. Check the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`;
+
+            const commentId = '${{ steps.post-comment.outputs.comment_id }}';
+
+            if (commentId) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: parseInt(commentId),
+                body
+              });
+              return;
+            }
+
+            // Fallback: no comment was posted at the start (no open PR at that time)
+            const branch = '${{ github.ref_name }}';
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -111,74 +203,15 @@ jobs:
               issue_number
             });
 
-            const previewComment = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment ready')
+            const existing = comments.find(
+              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
             );
 
-            if (previewComment) {
+            if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: previewComment.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number,
-                body
-              });
-            }
-
-  comment-preview-on-pr:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-
-    steps:
-      - name: Set preview app name and domain
-        run: |
-          BRANCH_SLUG=$(echo "${{ github.event.pull_request.head.ref }}" \
-            | tr '[:upper:]' '[:lower:]' \
-            | sed 's/[^a-z0-9-]/-/g' \
-            | sed 's/-\+/-/g' \
-            | sed 's/^-//;s/-$//')
-
-          APP_NAME="fairdataihub-website-${BRANCH_SLUG}"
-          APP_DOMAIN="website-${BRANCH_SLUG}.fairdataihub.org"
-
-          echo "KAMAL_APP_NAME=${APP_NAME}" >> "$GITHUB_ENV"
-          echo "KAMAL_APP_DOMAIN=${APP_DOMAIN}" >> "$GITHUB_ENV"
-
-      - name: Comment preview URL on PR
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
-          script: |
-            const previewUrl = 'https://${{ env.KAMAL_APP_DOMAIN }}';
-            const issue_number = context.payload.pull_request.number;
-
-            const body = `## Preview deployment ready\n\n**Preview URL:** [${previewUrl}](${previewUrl})`;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number
-            });
-
-            const previewComment = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment ready')
-            );
-
-            if (previewComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previewComment.id,
+                comment_id: existing.id,
                 body
               });
             } else {
@@ -254,8 +287,21 @@ jobs:
 
       - run: kamal remove -y -d preview
 
-      - name: Deactivate GitHub deployment
-        if: success()
+      - name: Delete registry image
+        if: always()
+        uses: imjasonh/setup-crane@v0.4
+      - name: Remove preview image from registry
+        if: always()
+        run: |
+          crane auth login "$KAMAL_REGISTRY_LOGIN_SERVER" \
+            -u "$KAMAL_REGISTRY_USERNAME" \
+            -p "$KAMAL_REGISTRY_PASSWORD"
+          crane ls "$KAMAL_REGISTRY_LOGIN_SERVER/$KAMAL_APP_NAME" 2>/dev/null \
+            | xargs -I{} crane delete "$KAMAL_REGISTRY_LOGIN_SERVER/$KAMAL_APP_NAME:{}" 2>/dev/null \
+            || true
+
+      - name: Deactivate and delete GitHub environment
+        if: always()
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -263,8 +309,8 @@ jobs:
             const { data: deployments } = await github.rest.repos.listDeployments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              environment: '${{ env.KAMAL_APP_NAME }}',
-              per_page: 10
+              environment: process.env.KAMAL_APP_NAME,
+              per_page: 100
             });
 
             for (const deployment of deployments) {
@@ -277,15 +323,47 @@ jobs:
               });
             }
 
-      - name: Comment deployment removed on PR
-        if: github.event_name == 'pull_request' && success()
+            try {
+              await github.rest.repos.deleteAnEnvironment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment_name: process.env.KAMAL_APP_NAME
+              });
+            } catch (e) {
+              core.warning(`Could not delete environment: ${e.message}`);
+            }
+
+      - name: Update PR comment on removal
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            await github.rest.issues.createComment({
+            const issue_number = context.payload.pull_request.number;
+            const body = `## Preview deployment removed\n\nThe preview environment for this branch has been removed.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: '## Preview deployment removed\n\nThe preview environment for this branch has been removed.'
+              issue_number
             });
+
+            const existing = comments.find(
+              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body
+              });
+            }

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -1,7 +1,7 @@
 name: Deploy preview environment
 
 concurrency:
-  group: preview-app-deploy-${{ github.event_name }}-${{ github.ref_name || github.event.ref || github.event.pull_request.head.ref }}
+  group: preview-app-${{ github.ref_name || github.event.ref || github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -21,6 +21,7 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: read
+      deployments: write
       issues: write
       pull-requests: write
 
@@ -30,8 +31,8 @@ jobs:
       KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}
       KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
       KAMAL_SERVER_IP: ${{ secrets.KAMAL_SERVER_IP }}
-      KAMAL_APP_NAME: "fairdataihub-website"
-      KAMAL_APP_DOMAIN: "next.fairdataihub.org"
+      KAMAL_APP_NAME: 'fairdataihub-website'
+      KAMAL_APP_DOMAIN: 'next.fairdataihub.org'
     steps:
       - uses: actions/checkout@v4
 
@@ -61,6 +62,29 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - run: kamal deploy -d preview
+
+      - name: Create GitHub deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.ref,
+              environment: '${{ env.KAMAL_APP_NAME }}',
+              auto_merge: false,
+              required_contexts: []
+            });
+
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.data.id,
+              state: 'success',
+              environment_url: 'https://${{ env.KAMAL_APP_DOMAIN }}',
+              description: 'Preview deployment ready'
+            });
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
@@ -177,6 +201,7 @@ jobs:
        !contains(fromJson('["main","next"]'), github.event.ref))
     permissions:
       contents: read
+      deployments: write
       issues: write
       pull-requests: read
 
@@ -186,8 +211,8 @@ jobs:
       KAMAL_REGISTRY_USERNAME: ${{ secrets.KAMAL_REGISTRY_USERNAME }}
       KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
       KAMAL_SERVER_IP: ${{ secrets.KAMAL_SERVER_IP }}
-      KAMAL_APP_NAME: "fairdataihub-website"
-      KAMAL_APP_DOMAIN: "next.fairdataihub.org"
+      KAMAL_APP_NAME: 'fairdataihub-website'
+      KAMAL_APP_DOMAIN: 'next.fairdataihub.org'
 
     steps:
       - uses: actions/checkout@v4
@@ -228,6 +253,29 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - run: kamal remove -y -d preview
+
+      - name: Deactivate GitHub deployment
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: '${{ env.KAMAL_APP_NAME }}',
+              per_page: 10
+            });
+
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive',
+                description: 'Preview environment removed'
+              });
+            }
 
       - name: Comment deployment removed on PR
         if: github.event_name == 'pull_request' && success()

--- a/.github/workflows/deploy-preview-app.yml
+++ b/.github/workflows/deploy-preview-app.yml
@@ -10,7 +10,7 @@ on:
       - main
       - next
   pull_request:
-    types: [closed]
+    types: [opened, reopened, closed]
   delete:
 
 jobs:
@@ -76,7 +76,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             let commentId;
@@ -204,7 +204,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             if (existing) {
@@ -220,6 +220,113 @@ jobs:
                 repo: context.repo.repo,
                 issue_number,
                 body
+              });
+            }
+
+  notify-pr-on-open:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      !contains(fromJson('["main","next"]'), github.event.pull_request.head.ref)
+    permissions:
+      contents: read
+      deployments: read
+      actions: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Set preview app name and domain
+        run: |
+          BRANCH_SLUG=$(echo "${{ github.event.pull_request.head.ref }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9-]/-/g' \
+            | sed 's/-\+/-/g' \
+            | sed 's/^-//;s/-$//')
+
+          APP_NAME="fairdataihub-website-${BRANCH_SLUG}"
+          APP_DOMAIN="website-${BRANCH_SLUG}.fairdataihub.org"
+
+          echo "KAMAL_APP_NAME=${APP_NAME}" >> "$GITHUB_ENV"
+          echo "KAMAL_APP_DOMAIN=${APP_DOMAIN}" >> "$GITHUB_ENV"
+
+      - name: Post preview status comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          script: |
+            const previewUrl = `https://${process.env.KAMAL_APP_DOMAIN}`;
+            const issue_number = context.payload.pull_request.number;
+            const branch = context.payload.pull_request.head.ref;
+
+            // Look up the latest deployment for this preview environment
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: process.env.KAMAL_APP_NAME,
+              per_page: 1,
+            });
+
+            let body;
+            if (deployments.length > 0) {
+              const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployments[0].id,
+                per_page: 1,
+              });
+              const state = statuses[0]?.state;
+              if (state === 'success') {
+                const updatedAt = new Date(deployments[0].updated_at).toUTCString();
+                body = `## Preview deployment ready\n\n**Preview URL:** [${previewUrl}](${previewUrl})\n\n> Last deployed: ${updatedAt}`;
+              } else if (state === 'in_progress') {
+                body = `## Preview deployment in progress\n\nA preview environment is being built and will be available at [${previewUrl}](${previewUrl}) once ready. Please wait...`;
+              } else {
+                body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
+              }
+            } else {
+              // No deployment record yet — check if deploy-ui is currently running for this branch.
+              // The GitHub deployment record is only created after kamal completes, so a concurrent
+              // push can leave listDeployments empty while the workflow is still in progress.
+              const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch,
+                status: 'in_progress',
+                per_page: 10,
+              });
+              const deployRunning = runs.workflow_runs.some(r => r.name === 'Deploy preview environment');
+              if (deployRunning) {
+                body = `## Preview deployment in progress\n\nA preview environment is being built and will be available at [${previewUrl}](${previewUrl}) once ready. Please wait...`;
+              } else {
+                body = `## Preview deployment\n\nA preview environment will be available at [${previewUrl}](${previewUrl}) after the next push to this branch.`;
+              }
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            const existing = comments.find(
+              c => c.body.startsWith('## Preview deployment')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
               });
             }
 
@@ -304,7 +411,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           script: |
             const { data: deployments } = await github.rest.repos.listDeployments({
               owner: context.repo.owner,
@@ -320,6 +427,11 @@ jobs:
                 deployment_id: deployment.id,
                 state: 'inactive',
                 description: 'Preview environment removed'
+              });
+              await github.rest.repos.deleteDeployment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id
               });
             }
 
@@ -349,7 +461,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.startsWith('## Preview deployment')
+              c => c.body.startsWith('## Preview deployment')
             );
 
             if (existing) {

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ COPY --from=dependencies /app/node_modules ./node_modules
 COPY . .
 
 ENV NODE_ENV=production
-# Disable Next.js image optimization so images work when running behind a reverse proxy
-ENV NEXT_IMAGE_UNOPTIMIZED=true
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
@@ -82,17 +80,17 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-ENV NEXT_IMAGE_UNOPTIMIZED=true
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the run time.
 # ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy production dependencies and build output
-COPY --from=dependencies --chown=node:node /app/node_modules ./node_modules
-COPY --from=builder --chown=node:node /app/package.json ./package.json
-COPY --from=builder --chown=node:node /app/.next ./.next
+# Copy standalone server output (includes its own minimal node_modules)
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+# Static assets must sit at .next/static inside the standalone dir
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+# Public assets
 COPY --from=builder --chown=node:node /app/public ./public
 
 # Switch to non-root user for security best practices
@@ -101,5 +99,5 @@ USER node
 # Expose port 3000 to allow HTTP traffic
 EXPOSE 3000
 
-# Start Next.js server (matches "start" script in package.json)
-CMD ["node_modules/.bin/next", "start"]
+# Start the standalone server directly (no next CLI needed)
+CMD ["node", "server.js"]

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -66,8 +66,6 @@ builder:
 env:
   clear:
     NODE_ENV: production # Set to 'production' for production deployments
-    # Bypass Next.js image optimization so images work behind the proxy (see next.config.js)
-    NEXT_IMAGE_UNOPTIMIZED: 'true'
 # Use a different ssh user than root
 # Uncomment and configure if you need to use a non-root user for SSH access
 #

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  output: 'standalone',
   reactStrictMode: true,
   images: {
     // In Docker behind a reverse proxy (e.g. Kamal), the /_next/image endpoint can


### PR DESCRIPTION
The GH_TOKEN or GH_PAT will need a scope of repo or Environments: Read and write to allow the removal of deployment environments. This will help prevent the deployments page being cluttered with so many preview deployments. It should remove environments that are no longer needed/stale.

## Summary by Sourcery

Enhance preview and production deployment workflows with richer GitHub deployment tracking, automated cleanup, and improved Next.js standalone Docker packaging.

New Features:
- Post and maintain preview deployment status comments on pull requests, reflecting in-progress, ready, failed, and removed states.
- Create and update GitHub deployment records for preview and production environments, including environment URLs and status transitions.
- Introduce a scheduled workflow to detect and remove stale preview environments, their server deployments, registry images, and associated GitHub environments.

Enhancements:
- Unify and tighten preview workflow triggers and concurrency settings to better handle push and pull request events.
- Improve preview PR notifications to show the latest deployment status when a pull request is opened or reopened.
- Adjust Dockerfile and Next.js configuration to use Next.js standalone output for production builds, simplifying runtime dependencies and startup.
- Extend preview teardown workflow to clean up registry images, deactivate/delete GitHub deployments, and update existing PR comments instead of adding new ones.
- Add required GitHub token permissions for deployment-related operations in workflows.

Build:
- Add a dedicated cleanup-preview-envs GitHub Actions workflow to periodically purge stale preview environments and their resources.