### PR TITLE
feat: May 2026 event

### DIFF
--- a/events/NCAR-2026.md
+++ b/events/NCAR-2026.md
@@ -1,0 +1,31 @@
+---
+title: 'NCAR/NOAA/NLR Open Hackathon 2026'
+startDateTime: '2026-05-05T16:30:00'
+endDateTime: '2026-05-05T17:00:00'
+heroImage: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.1.0'
+subtitle: 'Applying FAIR principles to research software using Codefair.'
+type: 'Talk/Workshop'
+timeZone: 'America/Denver'
+location: 'Boulder, CO'
+---
+
+## 📝 Event Description
+
+The **NSF National Center for Atmospheric Research (NCAR), National Laboratory of the Rockies (NLR), and National Oceanic and Atmospheric Administration (NOAA) Open Hackathon 2026** is an event designed to facilitate collaboration between domain scientists, computational scientists, and research software engineers with the goal of improving and optimizing HPC applications or exploring and implementing new software features for research. More details are available on the [Open Hackathon website](https://www.openhackathons.org/s/siteevent/a0CUP00003FytYv2AJ/se000450).
+
+## 💡 Our Role / Contribution
+
+**Bhavesh Patel** will deliver a 30-minute **talk/workshop titled "Applying FAIR4RS Principles to Research Software Using Codefair"**. The presentation will introduce [Codefair](https://codefair.io), an open-source and free platform for making research software FAIR, and demonstrate how it can help researchers apply the FAIR4RS principles to their software, to improve software reusability, make software citable, comply with funders requirements, and more.
+
+## 📍 Location
+
+NCAR Mesa Lab, Boulder, Colorado
+
+## 🗓 Date and Time
+
+Tuesday, May 5, 2026  
+The talk/workshop is scheduled for 4:30–5:00 PM MT.
+
+## 🔗 Link to Materials
+
+Slides of the presentation and all related resources are available in this [GitHub repository](https://github.com/fairdataihub/codefair-OpenHackathon-2026).


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Document the NCAR/NOAA/NLR Open Hackathon 2026 event, including description, schedule, location, and links to materials for the Codefair FAIR4RS talk/workshop.