### PR TITLE
feat: add support for rss feeds

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "format": "prettier --ignore-path .gitignore \"src/**/*.+(ts|js|tsx|jsx)\" --write",
     "postinstall": "pnpm run scripts:gallery_id",
     "commit": "cz",
-    "postbuild": "next-sitemap",
+    "postbuild": "next-sitemap && pnpm run scripts:feeds",
     "semantic-release": "semantic-release",
     "scripts:gallery_id": "tsx scripts/gallery_id.ts",
+    "scripts:feeds": "tsx scripts/generate_feeds.ts",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run --browser chrome --headless \"cypress/e2e/**/*.cy.js\"",
     "reset": "rm -rf node_modules .next && pnpm install"

--- a/scripts/generate_feeds.ts
+++ b/scripts/generate_feeds.ts
@@ -1,0 +1,198 @@
+import dayjs from 'dayjs';
+import matter from 'gray-matter';
+import fs from 'node:fs';
+import path from 'node:path';
+
+type BlogFrontMatter = {
+  title?: string;
+  date?: string;
+  subtitle?: string;
+  author?: string;
+};
+
+type BlogPost = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  url: string;
+};
+
+const SITE_URL = 'https://fairdataihub.org';
+const BLOG_URL = `${SITE_URL}/blog`;
+const BLOG_DIR = path.resolve(process.cwd(), 'blog');
+const PUBLIC_DIR = path.resolve(process.cwd(), 'public');
+const BLOG_FEED_DIR = path.join(PUBLIC_DIR, 'blog');
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+const toRfc2822 = (dateInput: string) => {
+  const parsed = dayjs(dateInput);
+  return parsed.isValid()
+    ? parsed.toDate().toUTCString()
+    : new Date(dateInput).toUTCString();
+};
+
+const toIso8601 = (dateInput: string) => {
+  const parsed = dayjs(dateInput);
+  return parsed.isValid()
+    ? parsed.toDate().toISOString()
+    : new Date(dateInput).toISOString();
+};
+
+const readBlogPosts = (): BlogPost[] => {
+  const files = fs
+    .readdirSync(BLOG_DIR)
+    .filter((fileName) => fileName.endsWith('.md'));
+
+  const posts = files
+    .map((fileName) => {
+      const slug = fileName.replace(/\.md$/, '');
+      const raw = fs.readFileSync(path.join(BLOG_DIR, fileName), 'utf-8');
+      const { data } = matter(raw);
+      const frontMatter = data as BlogFrontMatter;
+      const title = frontMatter.title?.trim();
+      const date = frontMatter.date?.trim();
+
+      if (!title || !date) {
+        return null;
+      }
+
+      const description =
+        frontMatter.subtitle?.trim() ||
+        'New update from FAIR Data Innovations Hub.';
+
+      return {
+        slug,
+        title,
+        description,
+        date,
+        author: frontMatter.author?.trim() || 'FAIR Data Innovations Hub',
+        url: `${BLOG_URL}/${slug}`,
+      };
+    })
+    .filter((post): post is BlogPost => Boolean(post));
+
+  posts.sort((a, b) => {
+    const aDate = dayjs(a.date);
+    const bDate = dayjs(b.date);
+
+    if (!aDate.isValid() || !bDate.isValid()) {
+      return 0;
+    }
+
+    return bDate.valueOf() - aDate.valueOf();
+  });
+
+  return posts;
+};
+
+const buildRss = (posts: BlogPost[]) => {
+  const latestDate = posts[0]
+    ? toRfc2822(posts[0].date)
+    : new Date().toUTCString();
+
+  const items = posts
+    .map((post) => {
+      const title = escapeXml(post.title);
+      const description = escapeXml(post.description);
+      const link = escapeXml(post.url);
+      const guid = escapeXml(post.url);
+      const pubDate = escapeXml(toRfc2822(post.date));
+
+      return [
+        '    <item>',
+        `      <title>${title}</title>`,
+        `      <description>${description}</description>`,
+        `      <link>${link}</link>`,
+        `      <guid isPermaLink="true">${guid}</guid>`,
+        `      <pubDate>${pubDate}</pubDate>`,
+        '    </item>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0">',
+    '  <channel>',
+    '    <title>FAIR Data Innovations Hub Blog</title>',
+    `    <link>${escapeXml(BLOG_URL)}</link>`,
+    '    <description>Updates and implementation guides from FAIR Data Innovations Hub.</description>',
+    '    <language>en-us</language>',
+    `    <lastBuildDate>${escapeXml(latestDate)}</lastBuildDate>`,
+    ...(items ? [items] : []),
+    '  </channel>',
+    '</rss>',
+    '',
+  ].join('\n');
+};
+
+const buildAtom = (posts: BlogPost[]) => {
+  const latestDate = posts[0]
+    ? toIso8601(posts[0].date)
+    : new Date().toISOString();
+
+  const entries = posts
+    .map((post) => {
+      const title = escapeXml(post.title);
+      const id = escapeXml(post.url);
+      const link = escapeXml(post.url);
+      const updated = escapeXml(toIso8601(post.date));
+      const summary = escapeXml(post.description);
+      const author = escapeXml(post.author);
+
+      return [
+        '  <entry>',
+        `    <title>${title}</title>`,
+        `    <id>${id}</id>`,
+        `    <link href="${link}" />`,
+        `    <updated>${updated}</updated>`,
+        `    <summary>${summary}</summary>`,
+        '    <author>',
+        `      <name>${author}</name>`,
+        '    </author>',
+        '  </entry>',
+      ].join('\n');
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    '  <title>FAIR Data Innovations Hub Blog</title>',
+    '  <id>https://fairdataihub.org/blog</id>',
+    '  <link href="https://fairdataihub.org/blog/atom.xml" rel="self" />',
+    '  <link href="https://fairdataihub.org/blog" />',
+    `  <updated>${escapeXml(latestDate)}</updated>`,
+    ...(entries ? [entries] : []),
+    '</feed>',
+    '',
+  ].join('\n');
+};
+
+const writeFeeds = () => {
+  const posts = readBlogPosts();
+
+  fs.mkdirSync(BLOG_FEED_DIR, { recursive: true });
+
+  const rss = buildRss(posts);
+  const atom = buildAtom(posts);
+
+  fs.writeFileSync(path.join(BLOG_FEED_DIR, 'rss.xml'), rss, 'utf-8');
+  fs.writeFileSync(path.join(BLOG_FEED_DIR, 'atom.xml'), atom, 'utf-8');
+  fs.writeFileSync(path.join(PUBLIC_DIR, 'rss.xml'), rss, 'utf-8');
+  fs.writeFileSync(path.join(PUBLIC_DIR, 'atom.xml'), atom, 'utf-8');
+
+  // eslint-disable-next-line no-console
+  console.log(`Generated RSS and Atom feeds for ${posts.length} blog posts.`);
+};
+
+writeFeeds();

--- a/scripts/generate_feeds.ts
+++ b/scripts/generate_feeds.ts
@@ -7,7 +7,23 @@ type BlogFrontMatter = {
   title?: string;
   date?: string;
   subtitle?: string;
-  author?: string;
+  authors?: string[];
+};
+
+type AuthorEntry = { name: string };
+type AuthorsJson = Record<string, AuthorEntry>;
+
+const AUTHORS_JSON_PATH = path.resolve(
+  process.cwd(),
+  'src/assets/data/authors.json',
+);
+const authorsJson: AuthorsJson = JSON.parse(
+  fs.readFileSync(AUTHORS_JSON_PATH, 'utf-8'),
+);
+
+const resolveAuthors = (ids: string[] | undefined): string => {
+  if (!ids || ids.length === 0) return 'FAIR Data Innovations Hub';
+  return ids.map((id) => authorsJson[id]?.name ?? id).join(', ');
 };
 
 type BlogPost = {
@@ -74,7 +90,7 @@ const readBlogPosts = (): BlogPost[] => {
         title,
         description,
         date,
-        author: frontMatter.author?.trim() || 'FAIR Data Innovations Hub',
+        author: resolveAuthors(frontMatter.authors),
         url: `${BLOG_URL}/${slug}`,
       };
     })
@@ -107,6 +123,8 @@ const buildRss = (posts: BlogPost[]) => {
       const guid = escapeXml(post.url);
       const pubDate = escapeXml(toRfc2822(post.date));
 
+      const author = escapeXml(post.author);
+
       return [
         '    <item>',
         `      <title>${title}</title>`,
@@ -114,6 +132,7 @@ const buildRss = (posts: BlogPost[]) => {
         `      <link>${link}</link>`,
         `      <guid isPermaLink="true">${guid}</guid>`,
         `      <pubDate>${pubDate}</pubDate>`,
+        `      <author>${author}</author>`,
         '    </item>',
       ].join('\n');
     })
@@ -121,10 +140,11 @@ const buildRss = (posts: BlogPost[]) => {
 
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
-    '<rss version="2.0">',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
     '  <channel>',
     '    <title>FAIR Data Innovations Hub Blog</title>',
     `    <link>${escapeXml(BLOG_URL)}</link>`,
+    `    <atom:link href="${escapeXml(`${BLOG_URL}/rss.xml`)}" rel="self" type="application/rss+xml" />`,
     '    <description>Updates and implementation guides from FAIR Data Innovations Hub.</description>',
     '    <language>en-us</language>',
     `    <lastBuildDate>${escapeXml(latestDate)}</lastBuildDate>`,

--- a/src/components/project/infoSection.tsx
+++ b/src/components/project/infoSection.tsx
@@ -50,7 +50,7 @@ const ProjectInfoSection: React.FC<InfoSectionProps> = ({
     <section className="mx-auto max-w-screen-2xl px-4 py-10 sm:px-6 lg:px-10">
       <MagicCard
         gradientColor="oklch(0.592 0.2157 349.761)"
-        className="w-full rounded-3xl p-[2px]"
+        className="w-full rounded-3xl p-0.5"
       >
         <div className="rounded-3xl border border-stone-200 bg-white/90 p-6 shadow-[0_16px_50px_rgba(15,23,42,0.06)] lg:p-8">
           <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
@@ -98,7 +98,7 @@ const ProjectInfoSection: React.FC<InfoSectionProps> = ({
                           height={18}
                         />
                       </span>
-                      <span className="pointer-events-none absolute -bottom-1 left-1/2 h-[2px] w-0 bg-pink-600 transition-all duration-300 group-hover/link:left-0 group-hover/link:w-full" />
+                      <span className="pointer-events-none absolute -bottom-1 left-1/2 h-0.5 w-0 bg-pink-600 transition-all duration-300 group-hover/link:left-0 group-hover/link:w-full" />
                     </a>
                   ))}
                 </div>
@@ -115,7 +115,7 @@ const ProjectInfoSection: React.FC<InfoSectionProps> = ({
                   <img
                     src={sideImageSrc}
                     alt={sideImageAlt}
-                    className="h-auto w-[150px]"
+                    className="h-auto w-37.5"
                   />
                 </a>
               </div>

--- a/src/components/project/projectCard.tsx
+++ b/src/components/project/projectCard.tsx
@@ -30,10 +30,10 @@ export default function ProjectCard({ project }: { project: Project }) {
       aria-label={`${title} - open project`}
     >
       <article
-        className="relative grid h-full min-h-[28rem] overflow-hidden rounded-xl border border-stone-200 bg-white/90 shadow-sm transition-all duration-300 hover:border-pink-300"
+        className="relative grid h-full min-h-112 overflow-hidden rounded-xl border border-stone-200 bg-white/90 shadow-sm transition-all duration-300 hover:border-pink-300"
         style={{ gridTemplateRows: `auto 1fr` }}
       >
-        <div className="relative h-44 w-full overflow-hidden bg-gradient-to-b from-stone-50 to-white dark:from-stone-900 dark:to-stone-900">
+        <div className="relative h-44 w-full overflow-hidden bg-linear-to-b from-stone-50 to-white dark:from-stone-900 dark:to-stone-900">
           <div
             aria-hidden
             className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
@@ -96,7 +96,7 @@ export default function ProjectCard({ project }: { project: Project }) {
                 className="group-hover:text-primary group-active:text-primary h-4 w-4 transition-colors"
                 aria-hidden="true"
               />
-              <span className="bg-primary absolute -bottom-1 left-1/2 h-[2px] w-0 transition-all duration-300 group-hover:left-0 group-hover:w-full group-active:left-0 group-active:w-full" />
+              <span className="bg-primary absolute -bottom-1 left-1/2 h-0.5 w-0 transition-all duration-300 group-hover:left-0 group-hover:w-full group-active:left-0 group-active:w-full" />
             </div>
           </div>
         </div>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -35,6 +35,19 @@ class MyDocument extends Document {
           <meta name="twitter:card" content="summary_large_image" />
           <meta name="twitter:domain" content="fairdataihub.org" />
 
+          <link
+            rel="alternate"
+            type="application/rss+xml"
+            title="FAIR Data Innovations Hub Blog RSS Feed"
+            href="https://fairdataihub.org/blog/rss.xml"
+          />
+          <link
+            rel="alternate"
+            type="application/atom+xml"
+            title="FAIR Data Innovations Hub Blog Atom Feed"
+            href="https://fairdataihub.org/blog/atom.xml"
+          />
+
           <link rel="shortcut icon" href="/favicon.ico" />
           <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '@iconify/react';
 import dayjs from 'dayjs';
 import { AnimatePresence, motion } from 'framer-motion';
 import fs from 'fs';
@@ -38,9 +39,9 @@ export default function Blog({ blogList }: BlogProps) {
       />
 
       <div aria-hidden className="pointer-events-none fixed inset-0 -z-10">
-        <div className="absolute top-0 left-1/2 h-[720px] w-[1000px] -translate-x-1/2 bg-[radial-gradient(ellipse_at_center,rgba(211,75,171,0.30),rgba(211,75,171,0.12)_40%,transparent_75%)] blur-3xl" />
+        <div className="absolute top-0 left-1/2 h-180 w-250 -translate-x-1/2 bg-[radial-gradient(ellipse_at_center,rgba(211,75,171,0.30),rgba(211,75,171,0.12)_40%,transparent_75%)] blur-3xl" />
       </div>
-      <section className="container mx-auto max-w-screen-xl px-4 pt-8 pb-16">
+      <section className="container mx-auto max-w-7xl px-4 pt-8 pb-16">
         <Seo
           templateTitle="Blog"
           templateUrl="https://fairdataihub.org/blog"
@@ -77,7 +78,33 @@ export default function Blog({ blogList }: BlogProps) {
               Updates, implementation guides, and FAIR practices from our team.
             </p>
           </div>
-          <div className="via-primary/60 h-px w-full bg-gradient-to-r from-transparent to-transparent" />
+
+          <div className="via-primary/60 h-px w-full bg-linear-to-r from-transparent to-transparent" />
+
+          <div>
+            Subscribe with your favorite feed reader:
+            <div className="mt-2 ml-2 inline-flex flex-wrap items-center gap-2">
+              <a
+                href="/blog/rss.xml"
+                className="text-primary bg-accent/20 items border-center duration p relative inline-flex gap-1 rounded-md border px-1 text-sm font-semibold transition-colors"
+              >
+                <span className="relative z-20 inline-flex items-center gap-1">
+                  RSS Feed
+                  <Icon icon="line-md:rss" width="12" height="12" />
+                </span>
+              </a>
+
+              <a
+                href="/blog/atom.xml"
+                className="text-primary bg-accent/20 items border-center duration p relative inline-flex gap-1 rounded-md border px-1 text-sm font-semibold transition-colors"
+              >
+                <span className="relative z-20 inline-flex items-center gap-1">
+                  Atom Feed
+                  <Icon icon="boxicons:atom" width="12" height="12" />
+                </span>
+              </a>
+            </div>
+          </div>
         </motion.header>
 
         <h2 className="mb-4 text-sm font-semibold tracking-wider text-stone-500 uppercase">
@@ -110,7 +137,7 @@ export default function Blog({ blogList }: BlogProps) {
           </div>
         )}
 
-        <div className="via-primary/60 mb-6 h-px w-full bg-gradient-to-r from-transparent to-transparent" />
+        <div className="via-primary/60 l bg-linear-to-r from-transparent to-transparent" />
 
         <h2 className="mb-3 text-sm font-semibold tracking-wider text-stone-500 uppercase">
           Previous posts


### PR DESCRIPTION
## Summary by Sourcery

Add automated generation and exposure of blog RSS and Atom feeds, and update related UI and metadata.

New Features:
- Expose RSS and Atom feed subscription links on the blog page.
- Generate RSS and Atom feeds for blog posts from markdown front matter during the build process.
- Advertise RSS and Atom feeds in the HTML document head for feed discovery.

Enhancements:
- Adjust blog layout and gradients for consistency with design tokens.
- Refine project info and project card styling, including dimensions, borders, and gradients.

Build:
- Extend the postbuild script to generate blog feeds via a new feed generation script.